### PR TITLE
Benchmark API and Program Options refactored

### DIFF
--- a/cmake/FindOpenCL.cmake
+++ b/cmake/FindOpenCL.cmake
@@ -6,7 +6,7 @@
 #
 # To set manually the paths, define these environment variables:
 # OpenCL_INCPATH    - Include path (e.g. OpenCL_INCPATH=/opt/cuda/4.0/cuda/include)
-# OpenCL_LIBPATH    - Library path (e.h. OpenCL_LIBPATH=/usr/lib64/nvidia)
+# OpenCL_LIBPATH    - Library path (e.g. OpenCL_LIBPATH=/usr/lib64/nvidia)
 #
 # Once done this will define
 #  OPENCL_FOUND            - system has OpenCL
@@ -15,13 +15,9 @@
 #  OPENCL_HAS_CPP_BINDINGS - system has also cl.hpp
 
 # 0.2.0 added variables for our cluster environment
+# 0.3.0 further paths to find OpenCL
 
 FIND_PACKAGE(PackageHandleStandardArgs)
-
-SET (OPENCL_VERSION_STRING "0.2.0")
-SET (OPENCL_VERSION_MAJOR 0)
-SET (OPENCL_VERSION_MINOR 2)
-SET (OPENCL_VERSION_PATCH 0)
 
 IF (APPLE)
 
@@ -136,8 +132,8 @@ ELSE (APPLE)
 	ELSE (WIN32) # linux
   
   		IF (CYGWIN)
-    		SET (CMAKE_FIND_LIBRARY_SUFFIXES .lib)
-    		SET (OCL_LIB_SUFFIX .lib)
+                  SET (CMAKE_FIND_LIBRARY_SUFFIXES .lib)
+                  SET (OCL_LIB_SUFFIX .lib)
   		ENDIF (CYGWIN)
 
                 IF( NOT DEFINED OPENCL_ROOT AND DEFINED ENV{OPENCL_ROOT} )
@@ -152,9 +148,9 @@ ELSE (APPLE)
 
 		# Unix style platforms
 		FIND_LIBRARY(OPENCL_LIBRARIES OpenCL${OCL_LIB_SUFFIX}
-			PATHS ENV LD_LIBRARY_PATH 
-                        ENV OpenCL_LIBPATH 
-                        OPENCL_LIB
+                  PATHS ENV LD_LIBRARY_PATH
+                  PATHS ENV OpenCL_LIBPATH
+                  OPENCL_LIB
 		)
 
 		GET_FILENAME_COMPONENT(OPENCL_LIB_DIR ${OPENCL_LIBRARIES} PATH)
@@ -166,13 +162,13 @@ ELSE (APPLE)
 		FIND_PATH(OPENCL_INCLUDE_DIRS 
                   NAMES "cl.h"
                   PATHS ${_OPENCL_INC_CAND} 
-                  PATHS "/usr/local/cuda/include" 
-                  "/opt/AMDAPP/include" 
-                  ENV OpenCL_INCPATH
+                  PATHS "/usr/local/cuda/include"
+                  PATHS "/usr/cuda/include"
+                  PATHS "/opt/cuda/include"
+                  PATHS "/opt/AMDAPP/include"
+                  PATHS ENV OpenCL_INCPATH
                   PATHS ${OPENCL_INC}
                   PATH_SUFFIXES "CL")
-
-		FIND_PATH(_OPENCL_CPP_INCLUDE_DIRS CL/cl.hpp PATHS ${_OPENCL_INC_CAND} "/usr/local/cuda/include" "/opt/AMDAPP/include" ENV OpenCL_INCPATH OPENCL_INC)
 
 	ENDIF (WIN32)
 

--- a/inc/core/application.hpp
+++ b/inc/core/application.hpp
@@ -30,11 +30,16 @@ namespace gearshifft {
       return getInstance().context_;
     }
 
+    bool isContextCreated() const {
+      return context_created_;
+    }
+
     void createContext() {
       TimerCPU timer;
       timer.startTimer();
       context_.create();
       timeContextCreate_ = timer.stopTimer();
+      context_created_ = true;
     }
 
     void destroyContext() {
@@ -42,6 +47,7 @@ namespace gearshifft {
       timer.startTimer();
       context_.destroy();
       timeContextDestroy_ = timer.stopTimer();
+      context_created_ = false;
     }
 
     void addRecord(ResultT r) {
@@ -57,6 +63,7 @@ namespace gearshifft {
 
   private:
     T_Context context_;
+    bool context_created_ = false;
     ResultAllT resultAll_;
     ResultT result_;
     double timeContextCreate_ = 0.0;
@@ -66,19 +73,6 @@ namespace gearshifft {
     ~Application() = default;
   };
 
-  template<typename T_Context>
-  struct FixtureApplication {
-    using ApplicationT = Application<T_Context>;
-
-    FixtureApplication() {
-      ApplicationT::getInstance().createContext();
-    }
-    ~FixtureApplication() {
-      ApplicationT::getInstance().destroyContext();
-      ApplicationT::getInstance().dumpResults();
-    }
-  };
-
-}
+} // gearshifft
 
 #endif

--- a/inc/core/benchmark.hpp
+++ b/inc/core/benchmark.hpp
@@ -1,0 +1,82 @@
+#ifndef BENCHMARK_HPP_
+#define BENCHMARK_HPP_
+
+#define BOOST_TEST_NO_MAIN
+#define BOOST_TEST_ALTERNATIVE_INIT_API
+
+#include "application.hpp"
+#include "options.hpp"
+#include "benchmark_suite.hpp"
+
+#include <boost/test/included/unit_test.hpp>
+#include <boost/mpl/list.hpp>
+
+namespace gearshifft {
+
+  /// List alias
+  template<typename... Types>
+  using List = boost::mpl::list<Types...>;
+
+  /**
+   * Benchmark API class for clients.
+   *
+   */
+  template<typename Context>
+  class Benchmark {
+    using AppT = Application<Context>;
+
+  public:
+    Benchmark() = default;
+
+    ~Benchmark() {
+      if(AppT::getInstance().isContextCreated()) {
+        AppT::getInstance().destroyContext();
+      }
+    }
+
+    void configure(int argc, char* argv[]) {
+      configured_ = false;
+      std::vector<char*> vargv(argv, argv+argc);
+      boost_vargv_.clear();
+      boost_vargv_.emplace_back(argv[0]); // [0] = name of application
+
+      if( Options::getInstance().parse(vargv, boost_vargv_) ) {
+        if( gearshifft::Options::getInstance().getListDevices() ) {
+          std::cout << Context::getListDevices();
+        }
+      }
+      else
+        configured_ = true;
+    }
+
+    template<typename T_FFT_Is_Normalized,
+             typename T_FFTs,
+             typename T_Precisions>
+    void run() {
+      if(configured_==false)
+        return;
+
+      AppT::getInstance().createContext();
+
+      auto init_function = []() {
+        Run<Context, T_FFT_Is_Normalized, T_FFTs, T_Precisions> instance;
+        ::boost::unit_test::framework::master_test_suite().add( instance() );
+        return true;
+      };
+
+      ::boost::unit_test::unit_test_main( init_function,
+                                          boost_vargv_.size(),
+                                          boost_vargv_.data() );
+
+      AppT::getInstance().destroyContext();
+      AppT::getInstance().dumpResults();
+    }
+
+  private:
+    bool configured_ = false;
+    std::vector<char*> boost_vargv_;
+  };
+
+} // gearshifft
+
+#endif // BENCHMARK_HPP_

--- a/inc/core/benchmark_data.hpp
+++ b/inc/core/benchmark_data.hpp
@@ -47,14 +47,12 @@ namespace gearshifft {
 
     void copyTo(RealVector& vec) {
       vec.resize(size_);
-      for( size_t i : boost::counting_range(size_t(0), size_) ){
-        vec[i] = data_linear_[i];
-      }
+      std::copy(data_linear_.begin(), data_linear_.end(), vec.begin());
     }
 
     void copyTo(ComplexVector& vec) {
       vec.resize(size_);
-      for( size_t i : boost::counting_range(size_t(0), size_) ){
+      for( size_t i=0; i<size_; ++i ){
         vec[i].real(data_linear_[i]);
         vec[i].imag(0);
       }
@@ -65,7 +63,7 @@ namespace gearshifft {
       {
         double diff_sum = 0;
         double diff;
-        for( size_t i : boost::counting_range(size_t(0), size_) ){
+        for( size_t i=0; i<size_; ++i ){
           diff = sub<Normalize>(data,i);
           diff_sum += diff*diff;
         }
@@ -101,7 +99,7 @@ namespace gearshifft {
 
         // allocate variables for all test cases
         data_linear_.resize(size_);
-        for( size_t i : boost::counting_range(size_t(0), size_) )
+        for( size_t i=0; i<size_; ++i )
         {
           data_linear_[i] = 1.0*rand()/RAND_MAX;
         }

--- a/inc/core/options.hpp
+++ b/inc/core/options.hpp
@@ -41,7 +41,7 @@ namespace gearshifft {
     void parseExtent( const std::string& extent );
 
     /// processes command line arguments and apply the values to the variables
-    int process(int argc, char* argv[]);
+    int parse(std::vector<char*>&, std::vector<char*>&);
 
     const Extents1DVec& getExtents1D() const {
       return vector1D_;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -104,7 +104,7 @@ if(FFTW_FOUND)
   endif()
 
   set(FFTW_LIBRARIES ${FFTW_LIBS_TO_USE})
-  message(">> FFTW -> " ${FFTW_LIBRARIES} " " ${FFTW_INCLUDES})
+  message(">> FFTW -> ${FFTW_LIBRARIES} ${FFTW_INCLUDES}")
 else()
   message("<< FFTW benchmark disabled.")
 endif()

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -47,6 +47,7 @@ int main( int argc, char* argv[] )
 
   }catch(const std::runtime_error& e){
     std::cerr << e.what() << std::endl;
+    return 1;
   }
   return 0;
 }

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -1,15 +1,8 @@
-#include "core/benchmark_suite.hpp"
-#include "core/application.hpp"
-#include "core/options.hpp"
-
-#include <boost/test/included/unit_test.hpp>
-#include <boost/mpl/list.hpp>
-
-/// List alias
-template<typename... Types>
-using List = boost::mpl::list<Types...>;
+#include "core/benchmark.hpp"
 
 // ----------------------------------------------------------------------------
+template<typename... Types>
+using List = gearshifft::List<Types...>;
 
 #ifdef CUDA_ENABLED
 #include "libraries/cufft/cufft.hpp"
@@ -44,24 +37,16 @@ using FFT_Is_Normalized = std::false_type;
 
 // ----------------------------------------------------------------------------
 
-/// functor for gearshifft benchmarks
-gearshifft::Run<Context, FFT_Is_Normalized, FFTs, Precisions> instance;
-
-/// global application handler as global fixture
-using AppT = gearshifft::FixtureApplication<Context>;
-BOOST_GLOBAL_FIXTURE(AppT);
-
-/// called by Boost UTF
-boost::unit_test::test_suite* init_unit_test_suite( int argc, char* argv[] )
+int main( int argc, char* argv[] )
 {
-  // process extra command line arguments for gearshifft
-  //  if error or help is shown then do not run any benchmarks
-  if( gearshifft::Options::getInstance().process(argc, argv) == 0 ) {
-    if( gearshifft::Options::getInstance().getListDevices() ) {
-      std::cout << Context::getListDevices();
-      return nullptr;
-    }else
-      return instance();
-  }else
-    return nullptr;
+  try {
+    gearshifft::Benchmark<Context> benchmark;
+
+    benchmark.configure(argc, argv);
+    benchmark.run<FFT_Is_Normalized, FFTs, Precisions>();
+
+  }catch(const std::runtime_error& e){
+    std::cerr << e.what() << std::endl;
+  }
+  return 0;
 }


### PR DESCRIPTION
This PR is based on Issue #24 and open PR #26, so credits to @psteinb :)
- Refactoring of benchmark API for clients code. Boost calls are encapsulated to provide pure gearshifft interfaces.

```
int main( int argc, char* argv[] )                       
{                                                        
  try {                                                  
    gearshifft::Benchmark<Context> benchmark;                                                                     
    benchmark.configure(argc, argv);                     
    benchmark.run<FFT_Is_Normalized, FFTs, Precisions>();                                                         
  }catch(const std::runtime_error& e){                   
    std::cerr << e.what() << std::endl;
    return 1;                  
  }                                                      
  return 0;                                              
}                                                        
```
- gearshifft-only command line arguments (internally referring to Boost as appropriate)

```
./gearshifft_clfft -h
gearshifft options and flags:
  -h [ --help ]                     Print help messages
  -e [ --extent ] arg               specific extent (eg. 1024x1024) [>=1 nr. of
                                    args possible]
  -f [ --file ] arg                 file with extents (row-wise csv) [>=1 nr. 
                                    of args possible]
  -o [ --output ] arg (=result.csv) output csv file location
  -v [ --verbose ]                  for console output
  -d [ --device ] arg (=gpu)        Compute device = (gpu|cpu|acc|<ID>). If 
                                    device is not supported by FFT lib, then it
                                    is ignored and default is used.
  -l [ --list-devices ]             List of available compute devices with IDs,
                                    if supported.
  -b [ --list-benchmarks ]          Show registered benchmarks
  -r [ --run-benchmarks ] arg       Run specific benchmarks (wildcards 
                                    possible, e.g. ClFFT/float/*/Inplace_Real)
```
- added benchmark.hpp (Benchmark API of gearshifft)
- removed class FixtureApplication (was needed for Boost Global Fixturing)
- minor fixes to cmake files (OpenCL lib was not found on my laptop)
