### PR TITLE
Mistakenly added signal.hpp include removed…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 
+# cmake general setup
+
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 set(CMAKE_DISABLE_SOURCE_CHANGES  ON)
 
@@ -23,21 +25,45 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
 endif(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
 message(">> Setting up ${CMAKE_BUILD_TYPE} build")
 
-option(USE_CXX11_ABI "enable _GLIBCXX_USE_CXX11_ABI in GCC 5.0+" ON)
-option(USE_FFTW_OPENMP "use OpenMP parallel fftw libraries if found" ON)
-option(USE_FFTW_PTHREADS "use pthreads parallel fftw libraries if found" OFF)
+# gearshifft cmake options
+
+option(GEARSHIFFT_CXX11_ABI "enable _GLIBCXX_USE_CXX11_ABI in GCC 5.0+" ON)
+option(GEARSHIFFT_FFTW_OPENMP "use OpenMP parallel fftw libraries if found" ON)
+option(GEARSHIFFT_FFTW_PTHREADS "use pthreads parallel fftw libraries if found" OFF)
+option(GEARSHIFFT_CUFFT "Compile gearshifft_cufft if available?" ON)
+option(GEARSHIFFT_CLFFT "Compile gearshifft_clfft if available?" ON)
+option(GEARSHIFFT_FFTW  "Compile gearshifft_fftw if available?" ON)
+option(GEARSHIFFT_HCFFT "< Not implemented yet >" OFF)
+
+#
+
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-  if(${USE_CXX11_ABI})
+  if(${GEARSHIFFT_CXX11_ABI})
     add_definitions(-D_GLIBCXX_USE_CXX11_ABI=1)
+    message(">> CXX11_ABI enabled.")
   else()
     add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
+    message(">> CXX11_ABI disabled.")
   endif()
+
+  if (NOT (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.0
+        OR CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 5.0))
+    message(FATAL_ERROR "gearshifft requires g++ 5.0 or greater.")
+  endif()
+  #gcc4.8+ uses dwarf-4. If you have gdb <7.5 then use this line
+  #set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -gdwarf-2")
+  #gdb 7.0-7.5 may require
+  #set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fvar-tracking-assignments")
 endif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 
-# if libraries are compiled with different ABI, then set the matching version here
-#add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
-# or
-#add_definitions(-D_GLIBCXX_USE_CXX11_ABI=1)
+
+set(DEV_TESTS "" CACHE STRING "Tests for developing (No Benchmarks)")
+if(DEV_TESTS)
+  message(">> Test mode")
+  add_definitions(-DDEV_TESTS)
+  set(TESTS tests.cpp)
+endif()
 
 add_subdirectory(src)

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ This project is still in development.
 ## Build
 Go to the gearshifft directory (created by git clone ...):
 ```
-mkdir build && cd build
+mkdir release && cd release
 cmake ..
 make -j 4
 ```
 CMake tries to find the libraries and enables the corresponding make targets.
-After make have finished you can run e.g. `./gearshifft_cuFFT`.
+After make have finished you can run e.g. `./gearshifft_cufft`.
 
 ## Usage
 
@@ -90,12 +90,14 @@ Select compute devices by id returned by `--list-devices|-l`
 The FFT scenario is a roundtrip FFT, i.e. forward and backward transformation.
 The result is compared with the original input data and an error is shown, if there was a mismatch.
 If a benchmark cannot be completed due to an error, it proceeds with the next benchmark.
-The library dependent FFT steps are abstracted and some are wrapped by timers.
+The library dependent FFT steps are abstracted, where following steps are wrapped by timers.
 - buffer allocation
 - plan creation
 - memory transfers (up-/download)
 - forward and backward transforms
 - cleanup
+- timer which measures FFT process from upload to download (called "Time Device")
+- total time (allocation, plan, transfers, FFTs, cleanup)
 - device initialization/teardown (only once per runtime)
 
 ## CSV Output

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project is still in development.
 - CUDA FFT library cuFFT 7.5+ or clFFT 2.12.0+ (OpenCL) or FFTW 3.3.4+
 - Boost version 1.56+
   - should be compiled with same compiler version or ...
-  - ... disable the C++11 ABI for GCC with the `-DUSE_CXX11_ABI=OFF` cmake option 
+  - ... disable the C++11 ABI for GCC with the `-DGEARSHIFFT_CXX11_ABI=OFF` cmake option 
 
 ## Build
 Go to the gearshifft directory (created by git clone ...):
@@ -114,9 +114,9 @@ See CSV header for column titles.
 
 ## Tested on ...
 
-- gcc 5.3.0
-- CUDA 7.5.18
-- cuFFT from CUDA 7.5.18
+- gcc 5.3.0, gcc 6.2.0
+- CUDA 7.5.18, CUDA 8.0
+- cuFFT from CUDA 7.5.18 and CUDA 8.0
 - clFFT 2.12.0 and 2.12.1
 - FFTW 3.3.4 and 3.3.5
 - OpenCL 1.2-4.4.0.117 (Nvidia)
@@ -127,6 +127,7 @@ See CSV header for column titles.
 - cuFFT 7.5 contexts might become messed up after huge allocations failed (see [link](https://devtalk.nvidia.com/default/topic/956093/gpu-accelerated-libraries/cufft-out-of-memory-yields-quot-irreparable-quot-context/))
 - clFFT does not support arbitrary transform sizes. The benchmark renders such tests as failed.
 - At the moment this is for single-GPUs, batches are not considered
+- if gearshifft is killed before, no output is created, which might be an issue on a job scheduler system like slurm (exceeding memory assignment)
 
 ## Roadmap
 

--- a/inc/core/application.hpp
+++ b/inc/core/application.hpp
@@ -6,8 +6,6 @@
 #include "timer_cpu.hpp"
 #include "types.hpp"
 
-#include "signal.hpp"
-
 #include <vector>
 #include <array>
 

--- a/inc/libraries/cufft/cufft_helper.hpp
+++ b/inc/libraries/cufft/cufft_helper.hpp
@@ -67,6 +67,24 @@ namespace CuFFT {
 
     case CUFFT_UNALIGNED_DATA:
       return "CUFFT_UNALIGNED_DATA";
+
+    case CUFFT_INVALID_DEVICE:
+      return "CUFFT_INVALID_DEVICE";
+
+    case CUFFT_PARSE_ERROR:
+      return "CUFFT_PARSE_ERROR";
+
+    case CUFFT_NO_WORKSPACE:
+      return "CUFFT_NO_WORKSPACE";
+
+    case CUFFT_NOT_IMPLEMENTED:
+      return "CUFFT_NOT_IMPLEMENTED";
+
+    case CUFFT_LICENSE_ERROR:
+      return "CUFFT_LICENSE_ERROR";
+
+    case CUFFT_INCOMPLETE_PARAMETER_LIST:
+      return "CUFFT_INCOMPLETE_PARAMETER_LIST";
     }
     return "<unknown>";
   }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,21 +2,20 @@ cmake_minimum_required(VERSION 2.8)
 
 project(gearshifft CXX)
 
-list(APPEND CMAKE_MODULE_PATH "../cmake")
+include(CheckCXXCompilerFlag)
 
-set(CMAKE_CXX_STANDARD 14)
-
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-  if (NOT (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.0
-        OR CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 5.0))
-    message(FATAL_ERROR "${PROJECT_NAME} requires g++ 5.0 or greater.")
+if (CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|Clang|Intel)$")
+  CHECK_CXX_COMPILER_FLAG("-std=c++14" HAS_CPP14_FLAG)
+  if (HAS_CPP14_FLAG)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+  else()
+    message(FATAL_ERROR "gearshifft requires C++14 support!")
   endif()
-  set(CMAKE_CXX_FLAGS "--std=gnu++14" ${CMAKE_CXX_FLAGS})
-  #gcc4.8+ uses dwarf-4. If you have gdb <7.5 then use this line
-  #set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -gdwarf-2")
-  #gdb 7.0-7.5 may require
-  #set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fvar-tracking-assignments")
 endif()
+
+#------------------------------------------------------------------------------
+# Boost
+#------------------------------------------------------------------------------
 
 find_package(Boost 1.56 QUIET COMPONENTS unit_test_framework program_options REQUIRED)
 if(Boost_FOUND)
@@ -24,18 +23,12 @@ if(Boost_FOUND)
   link_directories(${Boost_LIBRARY_DIRS})
 endif()
 
-set(DEV_TESTS "" CACHE STRING "Tests for developing (No Benchmarks)")
-if(DEV_TESTS)
-  message(">> Test mode")
-  add_definitions(-DDEV_TESTS)
-  set(TESTS tests.cpp)
-endif()
-
 #------------------------------------------------------------------------------
 # CUDA+CUFFT
 #------------------------------------------------------------------------------
+
 find_package(CUDA)
-if(CUDA_FOUND)
+if(CUDA_FOUND AND GEARSHIFFT_CUFFT)
   include(FindCUDA)
   include_directories(${CUDA_INCLUDE_DIRS})
   list(APPEND FFTLIBS "cufft")
@@ -47,8 +40,9 @@ endif()
 #------------------------------------------------------------------------------
 # OPENCL+CLFFT
 #------------------------------------------------------------------------------
+
 find_package(OpenCL)
-if(OPENCL_FOUND)
+if(OPENCL_FOUND AND GEARSHIFFT_CLFFT)
   find_package(clFFT)
   if(CLFFT_FOUND)
     include_directories(${CLFFT_INCLUDE_DIRS})
@@ -64,8 +58,9 @@ endif()
 #------------------------------------------------------------------------------
 # ROCM+HCFFT
 #------------------------------------------------------------------------------
+
 find_package(hcFFT)
-if(HCFFT_FOUND)
+if(HCFFT_FOUND AND GEARSHIFFT_HCFFT)
   include_directories(${HCFFT_INCLUDE_DIRS})
   list(APPEND FFTLIBS "hcfft")
   message(">> hcFFT -> " ${HCFFT_LIBRARIES} " " ${HCFFT_INCLUDE_DIRS})
@@ -79,8 +74,9 @@ endif()
 #------------------------------------------------------------------------------
 # FFTW
 #------------------------------------------------------------------------------
+
 find_package(FFTW COMPONENTS float double)
-if(FFTW_FOUND)
+if(FFTW_FOUND AND GEARSHIFFT_FFTW)
   include_directories(${FFTW_INCLUDE_DIR})
   link_directories(${FFTW_LIBRARY_DIR})
   list(APPEND FFTLIBS "fftw")
@@ -90,13 +86,13 @@ if(FFTW_FOUND)
     list(APPEND FFTW_LIBS_TO_USE ${_LIBSTEM})
   endforeach()
 
-  if(USE_FFTW_OPENMP AND OPENMP_FOUND AND "${FFTW_LIBRARIES}" MATCHES ".*_omp.*")
+  if(GEARSHIFFT_FFTW_OPENMP AND OPENMP_FOUND AND "${FFTW_LIBRARIES}" MATCHES ".*_omp.*")
     foreach(_LIBSTEM IN LISTS FFTW_OPENMP_LIBS)
       list(APPEND FFTW_LIBS_TO_USE ${_LIBSTEM})
     endforeach()
   endif()
 
-  if(USE_FFTW_PTHREADS AND "${FFTW_LIBRARIES}" MATCHES ".*_threads.*")
+  if(GEARSHIFFT_FFTW_PTHREADS AND "${FFTW_LIBRARIES}" MATCHES ".*_threads.*")
     foreach(_LIBSTEM IN LISTS FFTW_THREADS_LIBS)
       list(APPEND FFTW_LIBS_TO_USE ${_LIBSTEM})
     endforeach()
@@ -110,13 +106,14 @@ else()
 endif()
 
 
-if(NOT (CLFFT_FOUND OR CUDA_FOUND OR HCFFT_FOUND OR FFTW_FOUND))
+if(NOT FFTLIBS)
   message(FATAL_ERROR ">> No FFT library for benchmark found !!!")
 endif()
 
 #------------------------------------------------------------------------------
 # Helper function to add specific FFT library benchmark
 #------------------------------------------------------------------------------
+
 function(add_exec Tlib)
   set(PROJECT_EXEC gearshifft_${Tlib})
   add_executable(${PROJECT_EXEC} ${SOURCES})
@@ -141,7 +138,8 @@ endfunction()
 #------------------------------------------------------------------------------
 #
 #------------------------------------------------------------------------------
-include_directories(../inc)
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../inc)
 
 enable_testing()
 add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --verbose)


### PR DESCRIPTION
Removed signal.hpp include (was part of a test before), this refers to #39 .
Some changes to the CMakeLists with more options for libs.
Small README changes.
clfft error strings added.

(also successfully tested with cuda 8 and unsupported gcc6)
