### PR TITLE
More cmake options. Data size fix (clfft, fftw).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,9 @@ option(GEARSHIFFT_CLFFT "Compile gearshifft_clfft if available?" ON)
 option(GEARSHIFFT_FFTW  "Compile gearshifft_fftw if available?" ON)
 option(GEARSHIFFT_HCFFT "< Not implemented yet >" OFF)
 
-#
+set(GEARSHIFFT_NUMBER_RUNS "10" CACHE STRING "Number of repetitions within a FFT benchmark.")
+set(GEARSHIFFT_NUMBER_WARMUPS "1" CACHE STRING "Number of warmups before FFT benchmark becomes measured.")
+set(GEARSHIFFT_ERROR_BOUND "0.00001" CACHE STRING "Error-bound for FFT benchmarks.")
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 

--- a/inc/core/result_all.hpp
+++ b/inc/core/result_all.hpp
@@ -111,7 +111,7 @@ namespace gearshifft {
      */
     void saveCSV(const std::string& fname,
                  const std::string& apptitle,
-                 const std::string& dev_infos,
+                 const std::string& meta_information,
                  double timerContextCreate,
                  double timerContextDestroy) {
       std::ofstream fs;
@@ -119,7 +119,7 @@ namespace gearshifft {
 
       fs.open(fname, std::ofstream::out);
       fs.precision(11);
-      fs << "; " << dev_infos << "\n"
+      fs << "; " << meta_information <<"\n"
          << "; \"Time_ContextCreate [ms]\", " << timerContextCreate << "\n"
          << "; \"Time_ContextDestroy [ms]\", " << timerContextDestroy  << "\n";
       // header

--- a/inc/libraries/clfft/clfft.hpp
+++ b/inc/libraries/clfft/clfft.hpp
@@ -227,13 +227,13 @@ namespace gearshifft
           throw std::runtime_error("Context has not been created.");
 
         extents_ = interpret_as::row_major(cextents);
-        extents_complex_ = extents_;
         n_ = std::accumulate(extents_.begin(),
                              extents_.end(),
                              1,
                              std::multiplies<size_t>());
         std::copy(extents_.begin(), extents_.end(), extents_cl_.begin());
 
+        extents_complex_ = extents_;
         if(IsComplex==false){
           extents_complex_.front() = (extents_.front()/2 + 1);
         }
@@ -243,7 +243,7 @@ namespace gearshifft
                                      1,
                                      std::multiplies<size_t>());
 
-        data_size_ = (IsInplace ? 2*n_complex_ : n_) * sizeof(value_type);
+        data_size_ = (IsInplaceReal ? 2*n_complex_ : n_) * sizeof(value_type);
         if(IsInplace==false)
           data_complex_size_ = n_complex_ * sizeof(ComplexType);
 
@@ -271,15 +271,10 @@ namespace gearshifft
           dist_       = n_;
         }
 
-        if(IsComplex==false){
-          strides_complex_[1] = extents_[0]/2+1;
-          strides_complex_[2] = n_complex_ / extents_[NDim-1];
-          dist_complex_       = n_complex_;
-        }else{ // Complex, inplace, outplace
-          strides_complex_[1] = extents_[0];
-          strides_complex_[2] = n_ / extents_[NDim-1];
-          dist_complex_       = n_;
-        }
+        strides_complex_[1] = extents_complex_[0];
+        strides_complex_[2] = n_complex_ / extents_complex_[NDim-1];
+        dist_complex_       = n_complex_;
+
         // if memory transfer must pad reals
         if(IsInplaceReal && NDim>1) {
           size_t width  = extents_[0] * sizeof(RealType);

--- a/inc/libraries/fftw/fftw.hpp
+++ b/inc/libraries/fftw/fftw.hpp
@@ -587,7 +587,7 @@ namespace fftw {
         const std::size_t max_z = (NDim >= 3 ? extents_[NDim-3] : 1);
         const std::size_t max_y = (NDim >= 2 ? extents_[NDim-2] : 1);
         const std::size_t max_x = extents_[NDim-1];
-        const std::size_t allocated_x = extents_complex_[NDim-1];
+        const std::size_t allocated_x = 2*(extents_[NDim-1]/2+1);
 
         std::size_t input_index = 0;
         std::size_t data_index = 0;
@@ -616,7 +616,7 @@ namespace fftw {
         const std::size_t max_z = (NDim >= 3 ? extents_[NDim-3] : 1);
         const std::size_t max_y = (NDim >= 2 ? extents_[NDim-2] : 1);
         const std::size_t max_x = extents_[NDim-1];
-        const std::size_t allocated_x = extents_complex_[NDim-1];
+        const std::size_t allocated_x = 2*(extents_[NDim-1]/2+1);
 
         std::size_t output_index = 0;
         std::size_t data_index = 0;

--- a/inc/libraries/fftw/fftw.hpp
+++ b/inc/libraries/fftw/fftw.hpp
@@ -467,7 +467,7 @@ namespace fftw {
                                      1,
                                      std::multiplies<size_t>());
 
-        data_size_ = (IsInplace ? 2*n_complex_ : n_) * sizeof(value_type);
+        data_size_ = (IsInplaceReal ? 2*n_complex_ : n_) * sizeof(value_type);
         if(IsInplace==false)
           data_complex_size_ = n_complex_ * sizeof(ComplexType);
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -117,6 +117,11 @@ endif()
 function(add_exec Tlib)
   set(PROJECT_EXEC gearshifft_${Tlib})
   add_executable(${PROJECT_EXEC} ${SOURCES})
+  target_compile_definitions(${PROJECT_EXEC} PUBLIC
+    -DGEARSHIFFT_NUMBER_RUNS=${GEARSHIFFT_NUMBER_RUNS}
+    -DGEARSHIFFT_NUMBER_WARMUPS=${GEARSHIFFT_NUMBER_WARMUPS}
+    -DGEARSHIFFT_ERROR_BOUND=${GEARSHIFFT_ERROR_BOUND}
+    )
   if (Tlib STREQUAL "cufft" OR DEV_TESTS STREQUAL "cufft")
     target_compile_definitions(${PROJECT_EXEC} PUBLIC -DCUDA_ENABLED)
     set(LIBS ${CUDA_LIBRARIES} ${CUDA_CUFFT_LIBRARIES})
@@ -124,11 +129,9 @@ function(add_exec Tlib)
     target_compile_definitions(${PROJECT_EXEC} PUBLIC -DOPENCL_ENABLED)
     set(LIBS ${CLFFT_LIBRARIES} ${OPENCL_LIBRARIES})
   endif()
-
-  if (Tlib MATCHES "fftw")
+  if (Tlib STREQUAL "fftw")
+    target_compile_definitions(${PROJECT_EXEC} PUBLIC -DFFTW_ENABLED)
     set(LIBS ${LIBS} ${FFTW_LIBRARIES})
-    set_target_properties(${PROJECT_EXEC}
-      PROPERTIES COMPILE_FLAGS "-DFFTW_ENABLED")
   endif()
 
   target_link_libraries(${PROJECT_EXEC} ${Boost_LIBRARIES} ${LIBS})


### PR DESCRIPTION
- more cmake options
  - number of runs
  - number of warmups
  - error bound
- fixes wrong data size computation (inplace-complex) for clfft and fftw
- output contains aforementioned cmake options
- output contains time stamp