### PR TITLE
fixes wrong avg computation in verbose mode.

### DIFF
--- a/inc/core/result_all.hpp
+++ b/inc/core/result_all.hpp
@@ -98,7 +98,7 @@ namespace gearshifft {
           }
           ss << std::setw(28)
             << static_cast<RecordType>(ival)
-             << ": " << std::setw(16) << sum/nruns
+             << ": " << std::setw(16) << sum/(T_NumberRuns-T_NumberWarmups)
              << " [avg]"
              << "\n";
         }


### PR DESCRIPTION
this only affects verbose (-v) mode, where the average of measured values of the runs is computed.