### PR TITLE
added install target, resolves #97

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -137,6 +137,7 @@ function(add_exec Tlib)
 
   target_link_libraries(${PROJECT_EXEC} ${Boost_LIBRARIES} ${LIBS})
   add_test(NAME ${PROJECT_EXEC} COMMAND ${PROJECT_EXEC})
+  install(TARGETS ${PROJECT_EXEC} DESTINATION bin)
 endfunction()
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
make install will install `gearshifft_***` to `CMAKE_INSTALL_PREFIX`.