### PR TITLE
dplyr in app.r messed up summarize in helper.r

### DIFF
--- a/rshiny/app.r
+++ b/rshiny/app.r
@@ -1,7 +1,6 @@
 ## requires packages DT, shiny, ...
 
 library(ggplot2)
-library(dplyr)
 library(shiny)
 
 source("helper.r")


### PR DESCRIPTION
Removed "dplyr" package from `app.r`. When loading dplyr before plyr strange things can happen^^.
The group_by+summarize function stopped working (returns only one result row, but without error), which I did not see in my tests as the rshiny server was still running with the correct loaded packages. After rshiny server restarts, the app stopped working.
