### PR TITLE
Adds cufft float16 support + option for precision-related error-bound.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ option(GEARSHIFFT_HCFFT "< Not implemented yet >" OFF)
 
 set(GEARSHIFFT_NUMBER_WARM_RUNS "10" CACHE STRING "Number of repetitions of an FFT benchmark after a warmup.")
 set(GEARSHIFFT_NUMBER_WARMUPS "2" CACHE STRING "Number of warmups of an FFT benchmark.")
-set(GEARSHIFFT_ERROR_BOUND "0.00001" CACHE STRING "Error-bound for FFT benchmarks.")
+set(GEARSHIFFT_ERROR_BOUND "0.00001" CACHE STRING "Error-bound for FFT benchmarks (<0 for dynamic error bound).")
 set(GEARSHIFFT_INSTALL_CONFIG_PATH "${CMAKE_INSTALL_PREFIX}/share/gearshifft/" CACHE STRING "Default install path of config files.")
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
@@ -64,6 +64,25 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 endif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 
 set(CMAKE_CXX_STANDARD 14)
+
+
+
+#------------------------------------------------------------------------------
+# half-code
+#------------------------------------------------------------------------------
+include(ExternalProject)
+ExternalProject_Add(half-code
+  PREFIX ${CMAKE_BINARY_DIR}/third-party
+  URL https://downloads.sourceforge.net/project/half/half/1.12.0/half-1.12.0.zip
+  URL_MD5 86d023c0729abf3465bcd55665a39013
+  INSTALL_COMMAND ""
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+  LOG_DOWNLOAD ON
+  LOG_CONFIGURE OFF
+  LOG_BUILD OFF
+  )
+include_directories(${CMAKE_BINARY_DIR}/third-party/src)
 
 #------------------------------------------------------------------------------
 # Boost

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ If you want to just browse our results, see the [raw benchmark data](https://www
 - Boost version 1.56+
   - should be compiled with same compiler version or ...
   - ... disable the C++11 ABI for GCC with the `-DGEARSHIFFT_CXX11_ABI=OFF` cmake option 
+- [half-code](http://half.sourceforge.net) by [Christian Rau](http://sourceforge.net/users/rauy) for float16 support (currently used for cufft half precision FFTs)
+  - if your Nvidia GPU does not support float16, you will see a `CUFFT_INVALID_DEVICE` message in the results
 
 ## Build
 
@@ -147,8 +149,8 @@ See CSV header for column titles and meta-information (memory, number of runs, e
 ## Tested on ...
 
 - linux (CentOS, RHEL, ArchLinux, Ubuntu)
-- gcc 5.3.0, gcc 6.2.0
-- cuFFT from CUDA 7.5.18 and CUDA 8.0.61
+- gcc 5.3.0, gcc 6.2.0, gcc 7.1.1
+- cuFFT from CUDA 7.5.18, CUDA 8.0.*, CUDA 9.0.69-RC
 - clFFT 2.12.0, 2.12.1, 2.12.2
 - FFTW 3.3.4, 3.3.5, 3.3.6pl1
 - OpenCL 1.2-4.4.0.117 (Nvidia, Intel)
@@ -164,10 +166,12 @@ See CSV header for column titles and meta-information (memory, number of runs, e
 - if gearshifft is killed before, no output is created, which might be an issue on a job scheduler system like slurm (exceeding memory assignment, out-of-memory killings)
 - in case the boost version (e.g. 1.62.0) you have is more recent than your cmake (say 2.8.12.2), use `cmake -DBoost_ADDITIONAL_VERSIONS=1.62.0 -DBOOST_ROOT=/path/to/boost/1.62.0 <more flags>`
 - Windows or MacOS is not supported yet, feel free to add a pull-request
+- cufft float16 transforms overflow at >=1048576 elements
 
 
 ## Results (FFTW)
-fftw/haswell contains results for FFTW_MEASURE, FFTW_ESTIMATE and FFTW_WISDOM_ONLY. The planning time limit is set to FFTW_NO_TIMELIMIT (can be set with cmake option GEARSHIFFT_FFTW_TIMELIMIT).
+
+fftw/haswell contains results for `FFTW_MEASURE`, `FFTW_ESTIMATE` and `FFTW_WISDOM_ONLY`. The planning time limit is set to `FFTW_NO_TIMELIMIT` (can be set with cmake option `GEARSHIFFT_FFTW_TIMELIMIT`).
 fftw was compiled with:
 ```
 --enable-static=yes --enable-shared=yes --with-gnu-ld  --enable-silent-rules --with-pic --enable-openmp --enable-sse2

--- a/inc/core/complex-half.hpp
+++ b/inc/core/complex-half.hpp
@@ -1,0 +1,54 @@
+#ifndef COMPLEX_HALF_H
+#define COMPLEX_HALF_H
+
+#include <half-code/include/half.hpp>
+
+#include <complex>
+
+using float16 = half_float::half;
+
+namespace gearshifft {
+
+template<typename T> class complex;
+
+  struct complex_float16 {
+    float16 real;
+    float16 imag;
+  };
+
+template<>
+class complex<float16> {
+
+public:
+  typedef float16 value_type;
+  typedef complex_float16 _ComplexT;
+
+
+  constexpr complex(_ComplexT __z) : _M_value(__z) { }
+
+  constexpr complex(float16 __r = float16(0), float16 __i = float16(0)) {
+    _M_value.real = __r;
+    _M_value.imag = __i;
+  }
+
+  constexpr float16
+  real() const { return _M_value.real; }
+
+  constexpr float16
+  imag() const { return _M_value.imag; }
+
+
+  template<typename T>
+  void
+  real(T __val) { _M_value.real = static_cast<float16>(__val); }
+
+  template<typename T>
+  void
+  imag(T __val) { _M_value.imag = static_cast<float16>(__val); }
+
+private:
+  _ComplexT _M_value;
+  };
+}
+
+#endif /* COMPLEX-HALF_H */

--- a/inc/core/get_memory_size.h
+++ b/inc/core/get_memory_size.h
@@ -4,6 +4,8 @@
  * License: Creative Commons Attribution 3.0 Unported License
  *          http://creativecommons.org/licenses/by/3.0/deed.en_US
  */
+#ifndef GET_MEMORY_SIZE_H
+#define GET_MEMORY_SIZE_H
 
 #if defined(_WIN32)
 #include <Windows.h>
@@ -23,7 +25,7 @@
 /**
  * Returns the size of physical memory (RAM) in bytes.
  */
-size_t getMemorySize( )
+inline size_t getMemorySize( )
 {
 #if defined(_WIN32) && (defined(__CYGWIN__) || defined(__CYGWIN32__))
   /* Cygwin under Windows. ------------------------------------ */
@@ -93,3 +95,5 @@ size_t getMemorySize( )
   return size_t(-1);/* Unknown OS. */
   #endif
 }
+
+#endif /* GET_MEMORY_SIZE_H */

--- a/inc/core/traits.hpp
+++ b/inc/core/traits.hpp
@@ -1,10 +1,19 @@
 #ifndef TRAITS_HPP_
 #define TRAITS_HPP_
 
+#include "types.hpp"
+
 namespace gearshifft {
 
   template <typename T_Precision>
   struct ToString;
+
+  template <>
+  struct ToString<float16>  {
+    static const char* value() {
+      return "float16";
+    }
+  };
 
   template <>
   struct ToString<float>  {

--- a/inc/libraries/cufft/cufft_helper.hpp
+++ b/inc/libraries/cufft/cufft_helper.hpp
@@ -1,6 +1,8 @@
 #ifndef CUFFT_HELPER_HPP_
 #define CUFFT_HELPER_HPP_
 
+#include "core/get_memory_size.h"
+
 #include <cuda_runtime.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -85,6 +87,9 @@ namespace CuFFT {
 
     case CUFFT_INCOMPLETE_PARAMETER_LIST:
       return "CUFFT_INCOMPLETE_PARAMETER_LIST";
+
+    case CUFFT_NOT_SUPPORTED:
+      return "CUFFT_NOT_SUPPORTED";
     }
     return "<unknown>";
   }
@@ -122,6 +127,7 @@ namespace CuFFT {
          << ", \"Multiprocessors\", "<< prop.multiProcessorCount
          << ", \"Memory [MiB]\", "<< t/1048576
          << ", \"MemoryFree [MiB]\", " << f/1048576
+         << ", \"HostMemory [MiB]\", "<< getMemorySize()/1048576
          << ", \"ECC enabled\", " << prop.ECCEnabled
          << ", \"MemClock [MHz]\", " << prop.memoryClockRate/1000
          << ", \"GPUClock [MHz]\", " << prop.clockRate/1000

--- a/inc/libraries/fftw/fftw.hpp
+++ b/inc/libraries/fftw/fftw.hpp
@@ -8,7 +8,7 @@
 #include "core/timer.hpp"
 #include "core/fft.hpp"
 #include "core/benchmark_suite.hpp"
-#include "get_memory_size.h"
+#include "core/get_memory_size.h"
 
 #include <string.h>
 #include <vector>

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -13,7 +13,7 @@ using FFTs              = List<Inplace_Real,
                                Inplace_Complex,
                                Outplace_Real,
                                Outplace_Complex>;
-using Precisions        = List<float, double>;
+using Precisions        = List<float16, float, double>;
 using FFT_Is_Normalized = std::false_type;
 
 #elif defined(OPENCL_ENABLED)


### PR DESCRIPTION
- requires half-code library for host-side float16 support (http://half.sourceforge.net, downloaded by cmake)
- cufft results also show available host memory like fftw (clfft client already has it by using OpenCL)
- by float16 overflows are possible yielding to NaNs or Inf in the result, which is treated as an error
  + at the moment overflows happen at 1 Mio elements due to the input data
- results now also contain the number of mismatches, the sample standard deviation of the error
  + appends two new columns to the csv

(results will follow in the gearshifft_results upstream)