### PR TITLE
Removing svn dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,8 @@ if(GEARSHIFFT_FLOAT16_SUPPORT)
   include(ExternalProject)
   ExternalProject_Add(half-code
     PREFIX ${CMAKE_BINARY_DIR}/third-party
-    SVN_REPOSITORY https://svn.code.sf.net/p/half/code/trunk
+    URL https://downloads.sourceforge.net/project/half/half/1.12.0/half-1.12.0.zip
+    URL_MD5 86d023c0729abf3465bcd55665a39013
     INSTALL_COMMAND ""
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""

--- a/cmake/FindclFFT.cmake
+++ b/cmake/FindclFFT.cmake
@@ -42,16 +42,28 @@ FIND_PATH(CLFFT_ROOT_DIR
   PATHS ENV CLFFT_ROOT
   DOC "clFFT root directory.")
 
+FIND_PATH(CLFFT_ROOT_DIR
+  NAMES include/clFFT.h
+  DOC "clFFT root directory.")
+
 FIND_PATH(_CLFFT_INCLUDE_DIRS
   NAMES clFFT.h
   PATHS ${CLFFT_ROOT_DIR}
   PATH_SUFFIXES "include"
   DOC "clFFT include directory")
 
+FIND_PATH(_CLFFT_INCLUDE_DIRS
+  NAMES clFFT.h
+  DOC "clFFT include directory")
+
 FIND_LIBRARY(_CLFFT_LIBRARY
   NAMES clFFT
   PATHS ${CLFFT_ROOT_DIR}
   PATH_SUFFIXES "lib" "lib64"
+  DOC "clFFT library directory")
+
+FIND_LIBRARY(_CLFFT_LIBRARY
+  NAMES clFFT
   DOC "clFFT library directory")
 
 


### PR DESCRIPTION
our file system has file locking disabled. therefor, svn does not work as it uses sqlite as a backend (which relies on file-locking). I removed the call to svn and replaced it with a direct download, can you please try on your end that his workds, please?