### PR TITLE
Further restrictions on clfft complex transform sizes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If you want to just browse our results, see the [raw benchmark data](https://www
 
 ## Requirements
 
-- cmake 3.1+
+- cmake 3.1+ or 3.6.2+ for allowing cmake to automatically download of half-code (float16 support)
 - C++14 capable compiler
 - CUDA FFT library cuFFT 8.0+ or clFFT 2.12.0+ (OpenCL) or FFTW 3.3.4+
 - Boost version 1.59+
@@ -160,6 +160,7 @@ See CSV header for column titles and meta-information (memory, number of runs, e
 
 - clFFT does not support arbitrary transform sizes. The benchmark renders such tests as failed.
 - clFFT on CPU cannot transform the 4096-FFT and 4096x4096-FFTs (see [this issue](https://github.com/clMathLibraries/clFFT/issues/171))
+- clFFT seems to have lower transform size limits on CPU than on GPU (a complex 16384x16384 segfaults on clfft CPU, while it works on GPU). gearshifft marks these cases as "Unsupported lengths" and skips them.
 - At the moment this is for single-GPUs, batches are not considered
 - if gearshifft is killed before, no output is created, which might be an issue on a job scheduler system like slurm (exceeding memory assignment, out-of-memory killings)
 - in case the boost version (e.g. 1.62.0) you have is more recent than your cmake (say 2.8.12.2), use `cmake -DBoost_ADDITIONAL_VERSIONS=1.62.0 -DBOOST_ROOT=/path/to/boost/1.62.0 <more flags>`

--- a/inc/libraries/clfft/clfft.hpp
+++ b/inc/libraries/clfft/clfft.hpp
@@ -251,7 +251,11 @@ namespace gearshifft
         // check supported sizes : http://clmathlibraries.github.io/clFFT/
         if((std::is_same<TPrecision,float>::value && n_>(1<<24) && IsComplex==false)
            ||
-           (std::is_same<TPrecision,double>::value && n_>(1<<22) && IsComplex==false))
+           (std::is_same<TPrecision,double>::value && n_>(1<<22) && IsComplex==false)
+           ||
+           (std::is_same<TPrecision,float>::value && n_>(1<<27) && IsComplex==true)
+           ||
+           (std::is_same<TPrecision,double>::value && n_>(1<<26) && IsComplex==true))
           throw std::runtime_error("Unsupported lengths.");
 
         queue_ = clCreateCommandQueue( context_.ctx, context_.device_used, 0, &err );


### PR DESCRIPTION
- clfft on CPU segfaults on `16384x16384`, so this PR also adds restriction to complex transforms
  - the clFFT doc only talks about real transforms, so numbers for complex case have been derived by testing (clFFT on CPU is more experimental as devs focus on GPUs)
- Readme includes cmake version hint (see PR #118 )
