### PR TITLE
lowered verbosity of FFTWWrappers find module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,7 +208,7 @@ endif()
 # FFTW Wrappers of MKL
 #------------------------------------------------------------------------------
 
-find_package(FFTWWrappers)
+find_package(FFTWWrappers QUIET)
 if(FFTWWrappers_FOUND) # found FFTWWrappers for GNU or Intel
   if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     if(FFTWWrappers_GNU_LIBRARIES)
@@ -228,7 +228,7 @@ if(FFTWWrappers_FOUND) # found FFTWWrappers for GNU or Intel
     message(WARNING "Could not detect GNU or Intel compiler.")
   endif()
 
-#  link_directories(${FFTWWrappers_LIBRARY_DIR})
+
 endif(FFTWWrappers_FOUND)
 
 if(FFTWWrappers_LIBRARIES)
@@ -242,7 +242,7 @@ if(FFTWWrappers_LIBRARIES)
   set(GEARSHIFFT_FFTW_USE_THREADS 1) #
 
   list(APPEND FFTLIBS fftwwrappers)
-  message(">> FFTWWrappers -> ${FFTWWrappers_LIBRARIES}")
+  message(">> FFTWWrappers found! ${FFTWWrappers_LIBRARIES}")
 else()
   message("<< FFTWWrappers benchmark disabled.")
 endif()

--- a/cmake/FindFFTWWrappers.cmake
+++ b/cmake/FindFFTWWrappers.cmake
@@ -162,7 +162,7 @@ endif()
 
 list(APPEND FFTWWrappers_MKL_LIBRARIES "m;dl")
 
-if(NOT FFTW_FIND_QUIETLY)
+if(NOT FFTWWrappers_FIND_QUIETLY)
   message("++ FindFFTWWrappers")
   message("++ FFTWWrappers_GNU_LIBRARIES    : ${FFTWWrappers_GNU_LIBRARIES}")
   message("++ FFTWWrappers_INTEL_LIBRARIES  : ${FFTWWrappers_INTEL_LIBRARIES}")


### PR DESCRIPTION
just found a bug in the way FFTWWrappers report their results