### PR TITLE
cmake/modules/FindFFTWWrappers.cmake: added broader search for libiomp5

### DIFF
--- a/cmake/modules/FindFFTWWrappers.cmake
+++ b/cmake/modules/FindFFTWWrappers.cmake
@@ -150,7 +150,8 @@ list(APPEND FFTWWrappers_MKL_LIBRARY_DIRS "${MKLROOT}/../tbb/lib/intel64/gcc4.4"
 find_library(
   MKL_IOMP5
   NAMES iomp5 libiomp5 libiomp5.a
-  PATHS ${MKLROOT} ${MKLROOT}/../compiler/lib/intel64 ${MKLROOT}/../tbb/lib/intel64/gcc4.4
+  PATHS ${MKLROOT} ${MKLROOT}/../compiler ${MKLROOT}/../tbb
+  PATH_SUFFIXES "lib/intel64_lin" "lib/intel64" "lib/intel64/gcc4.4"
   NO_DEFAULT_PATH
   )
 


### PR DESCRIPTION
The default install location of `libiomp5*` from the Intel MKL on Linux is `${MKLROOT}/../compiler/lib/intel64`. But for me the path above `${MKLROOT}` is not writable so I need to have a fully self-contained MKL in `${MKLROOT}`. It would be nice if `FindFFTWWrappers.cmake` can search also in `${MKLROOT}` for `libiomp5*`.
This PR adds support for this extended search. It should not have any negative consequences other than the search taking a tiny bit longer because two or three additional path combinations are tested.