### PR TITLE
test/test_cufft.cpp: added std::array header

### DIFF
--- a/test/test_cufft.cpp
+++ b/test/test_cufft.cpp
@@ -2,6 +2,7 @@
 
 #include "libraries/cufft/cufft_helper.hpp"
 #include <boost/test/included/unit_test.hpp> // Single-header usage variant
+#include <array>
 #include <iostream>
 
 using namespace gearshifft::CuFFT;


### PR DESCRIPTION
Microsoft Visual Studio 2017 x64 complains about unknown class std::array. This PR fixes a missing include of `<array>`. Please review.