### PR TITLE
Minor msvc fixes

### DIFF
--- a/inc/core/benchmark_data.hpp
+++ b/inc/core/benchmark_data.hpp
@@ -80,18 +80,12 @@ namespace gearshifft {
 
     template<bool Normalize>
     constexpr double sub(const ComplexVector& vector, size_t i) const {
-      if(Normalize)
-        return 1.0/size_ * (vector[i].real()) - static_cast<double>(data_linear_[i]);
-      else
-        return static_cast<double>( vector[i].real() - data_linear_[i] );
+      return Normalize ? 1.0/size_ * (vector[i].real()) - static_cast<double>(data_linear_[i]) : static_cast<double>( vector[i].real() - data_linear_[i] );
     }
 
     template<bool Normalize>
     constexpr double sub(const RealVector& vector, size_t i) const {
-      if(Normalize)
-        return 1.0/size_ * (vector[i]) - static_cast<double>(data_linear_[i]);
-      else
-        return static_cast<double>( vector[i] - data_linear_[i] );
+      return Normalize ? 1.0/size_ * (vector[i]) - static_cast<double>(data_linear_[i]) : static_cast<double>( vector[i] - data_linear_[i] );
     }
 
     void init_if_dim_changed(const Extent& extents) {

--- a/inc/core/traits.hpp
+++ b/inc/core/traits.hpp
@@ -35,7 +35,6 @@ namespace gearshifft {
   {
     typedef char one;
     typedef long two;
-    template <typename C> static one test( decltype(&C::title) ) ;
     template <typename C> static one test( decltype(&C::Title) ) ;
     template <typename C> static two test(...);
   public:


### PR DESCRIPTION
This PR includes two minor fixes that help with the build on MSVC. Both changes should not have negative effects on other platforms, or at least I could not see problems on Ubuntu 16.04 and 18.04 x86_64.
Sorry for the long lines in `inc/core/benchmark_data.hpp`, the code should be reformatted.