### PR TITLE
FFTWWrappers add 32bit support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,7 @@ target_compile_definitions(Common INTERFACE
   GEARSHIFFT_PRECISION_HALF_ONLY=${GEARSHIFFT_PRECISION_HALF_ONLY}
   GEARSHIFFT_PRECISION_SINGLE_ONLY=${GEARSHIFFT_PRECISION_SINGLE_ONLY}
   GEARSHIFFT_PRECISION_DOUBLE_ONLY=${GEARSHIFFT_PRECISION_DOUBLE_ONLY}
+  BOOST_ALL_NO_LIB=1
   )
 #TODO: check paths
 
@@ -406,7 +407,9 @@ if(GEARSHIFFT_BACKEND_FFTWWRAPPERS)
       endif()
 
       target_link_libraries(FFTWWrappers INTERFACE
-        -Wl,--start-group ${FFTWWrappers_MKL_LIBRARIES} -Wl,--end-group
+        $<$<CXX_COMPILER_ID:GNU>:-Wl,--start-group>
+        ${FFTWWrappers_MKL_LIBRARIES}
+        $<$<CXX_COMPILER_ID:GNU>:-Wl,--end-group>
         )
       message(STATUS " gearshifft::FFTWWrappers enabled.")
 

--- a/cmake/modules/FindFFTWWrappers.cmake
+++ b/cmake/modules/FindFFTWWrappers.cmake
@@ -20,6 +20,16 @@
 #   MKLROOT                        ... take the MKL libraries from here
 #
 
+if(GEARSHIFFT_USE_STATIC_LIBS)
+  set(PREFERENCE_LIBRARY_PREFIX "${CMAKE_STATIC_LIBRARY_PREFIX}")
+  set(PREFERENCE_LIBRARY_SUFFIX "${CMAKE_STATIC_LIBRARY_SUFFIX}")
+  message("FFTWWrappers will prefer libraries with prefix '${PREFERENCE_LIBRARY_PREFIX}' and suffix '${PREFERENCE_LIBRARY_SUFFIX}'")
+else()
+  set(PREFERENCE_LIBRARY_PREFIX)
+  set(PREFERENCE_LIBRARY_SUFFIX)
+  message("FFTWWrappers will prefer libraries with no prefix and no suffix")
+endif()
+
 #If environment variable FFTWWrappers_ROOT is defined, it has the same effect as the cmake variable
 if( NOT FFTWWrappers_ROOT AND DEFINED ENV{FFTWWrappers_ROOT} )
   if( EXISTS "$ENV{FFTWWrappers_ROOT}/" )
@@ -43,21 +53,21 @@ endif()
 #initialize library variables
 find_library(
   FFTWWrappers_GNU_LIBRARIES
-  NAMES fftw3xc_gnu fftw3xc_gnu.a
+  NAMES ${PREFERENCE_LIBRARY_PREFIX}fftw3xc_gnu${PREFERENCE_LIBRARY_SUFFIX} fftw3xc_gnu
   PATHS ${FFTWWrappers_ROOT}
   PATH_SUFFIXES "lib" "lib64"
   NO_DEFAULT_PATH
   )
 find_library(
   FFTWWrappers_GNU_LIBRARIES
-  NAMES fftw3xc_gnu fftw3xc_gnu.a
+  NAMES ${PREFERENCE_LIBRARY_PREFIX}fftw3xc_gnu${PREFERENCE_LIBRARY_SUFFIX} fftw3xc_gnu
   PATHS ${MKLROOT}
   PATH_SUFFIXES "lib/intel64_lin" "lib/intel64_mac" "lib/intel64"
   NO_DEFAULT_PATH
   )
 find_library(
   FFTWWrappers_GNU_LIBRARIES
-  NAMES fftw3xc_gnu fftw3xc_gnu.a
+  NAMES ${PREFERENCE_LIBRARY_PREFIX}fftw3xc_gnu${PREFERENCE_LIBRARY_SUFFIX} fftw3xc_gnu
   )
 
 if(EXISTS ${FFTWWrappers_GNU_LIBRARIES})
@@ -66,21 +76,21 @@ endif()
 
 find_library(
   FFTWWrappers_INTEL_LIBRARIES
-  NAMES fftw3xc_intel fftw3xc_intel.a
+  NAMES ${PREFERENCE_LIBRARY_PREFIX}fftw3xc_intel${PREFERENCE_LIBRARY_SUFFIX} fftw3xc_intel
   PATHS ${FFTWWrappers_ROOT}
   PATH_SUFFIXES "lib" "lib64"
   NO_DEFAULT_PATH
   )
 find_library(
   FFTWWrappers_INTEL_LIBRARIES
-  NAMES fftw3xc_intel fftw3xc_intel.a
+  NAMES ${PREFERENCE_LIBRARY_PREFIX}fftw3xc_intel${PREFERENCE_LIBRARY_SUFFIX} fftw3xc_intel
   PATHS ${MKLROOT}
   PATH_SUFFIXES "lib/intel64_lin" "lib/intel64_mac" "lib/intel64_win" "lib/intel64"
   NO_DEFAULT_PATH
 )
 find_library(
   FFTWWrappers_INTEL_LIBRARIES
-  NAMES fftw3xc_intel fftw3xc_intel.a
+  NAMES ${PREFERENCE_LIBRARY_PREFIX}fftw3xc_intel${PREFERENCE_LIBRARY_SUFFIX} fftw3xc_intel
 )
 
 if(EXISTS ${FFTWWrappers_INTEL_LIBRARIES})
@@ -128,7 +138,7 @@ endif()
 
 find_library(
   MKL_INTEL_LP64
-  NAMES mkl_intel_lp64 mkl_intel_lp64.a
+  NAMES ${PREFERENCE_LIBRARY_PREFIX}mkl_intel_lp64${PREFERENCE_LIBRARY_SUFFIX} mkl_intel_lp64
   PATHS ${MKLROOT}
   PATH_SUFFIXES "lib" "lib/intel64_lin" "lib/intel64_mac" "lib/intel64_win" "lib/intel64"
   NO_DEFAULT_PATH
@@ -142,7 +152,7 @@ endif()
 
 find_library(
   MKL_INTEL_THREAD
-  NAMES mkl_intel_thread mkl_intel_thread.a
+  NAMES ${PREFERENCE_LIBRARY_PREFIX}mkl_intel_thread${PREFERENCE_LIBRARY_SUFFIX} mkl_intel_thread
   PATHS ${MKLROOT}
   PATH_SUFFIXES "lib" "lib/intel64_lin" "lib/intel64_mac" "lib/intel64_win" "lib/intel64"
   NO_DEFAULT_PATH
@@ -156,7 +166,7 @@ endif()
 
 find_library(
   MKL_CORE
-  NAMES mkl_core mkl_core.a
+  NAMES ${PREFERENCE_LIBRARY_PREFIX}mkl_core${PREFERENCE_LIBRARY_SUFFIX} mkl_core
   PATHS ${MKLROOT}
   PATH_SUFFIXES "lib" "lib/intel64_lin" "lib/intel64_mac" "lib/intel64_win" "lib/intel64"
   NO_DEFAULT_PATH
@@ -171,6 +181,8 @@ endif()
 list(APPEND FFTWWrappers_MKL_LIBRARY_DIRS "${MKLROOT}/../compiler/lib/intel64")
 list(APPEND FFTWWrappers_MKL_LIBRARY_DIRS "${MKLROOT}/../tbb/lib/intel64/gcc4.4")
 
+# NOTE: According to Intel documentation, it is generally not recommended to
+# link against the static variants of the openMP libraries so we put them last:
 find_library(
   MKL_IOMP5
   NAMES iomp5 libiomp5.a libiomp5md

--- a/cmake/modules/FindFFTWWrappers.cmake
+++ b/cmake/modules/FindFFTWWrappers.cmake
@@ -9,7 +9,7 @@
 #   FFTWWrappers_INTEL_LIBRARIES   ... list of library that were build with the intel binary layout
 #   FFTWWrappers_MSVS_LIBRARIES    ... list of library that were build with the MSVS binary layout
 #   FFTWWrappers_LIBRARIES         ... list of library identifiers that were found (will be filled with serial/openmp/pthreads enabled file names if present, only stubs will be filled in not full paths)
-#   FFTWWrappers_MKL_LIBRARIES     ... list of library in the MKL that need to be linked to (intel64)
+#   FFTWWrappers_MKL_LIBRARIES     ... list of library in the MKL that need to be linked to
 #   FFTWWrappers_MKL_INCLUDE_DIR   ... folder containing fftw3.h
 #   FFTWWrappers_MKL_LIBRARY_DIRS  ... folder containing the libraries in FFTWWrappers_MKL_LIBRARIES
 #   FFTWWrappers_LIBRARY_DIR	   ... fftw library directory
@@ -17,7 +17,7 @@
 # The following variables will be checked by the function
 #   FFTWWrappers_ROOT              ... if set, the libraries are exclusively searched
 #                                      under this path
-#   MKLROOT                        ... take the MKL libraries from here
+#   MKL_ROOT                       ... take the MKL libraries from here
 #
 
 if(GEARSHIFFT_USE_STATIC_LIBS)
@@ -30,7 +30,7 @@ else()
   message("FFTWWrappers will prefer libraries with no prefix and no suffix")
 endif()
 
-#If environment variable FFTWWrappers_ROOT is defined, it has the same effect as the cmake variable
+# If environment variable FFTWWrappers_ROOT is defined, it has the same effect as the cmake variable
 if( NOT FFTWWrappers_ROOT AND DEFINED ENV{FFTWWrappers_ROOT} )
   if( EXISTS "$ENV{FFTWWrappers_ROOT}/" )
     set( FFTWWrappers_ROOT $ENV{FFTWWrappers_ROOT} )
@@ -39,13 +39,21 @@ if( NOT FFTWWrappers_ROOT AND DEFINED ENV{FFTWWrappers_ROOT} )
   endif()
 endif()
 
-#If environment variable MKLROOT is defined, it has the same effect as the cmake variable
-if( NOT MKLROOT AND DEFINED ENV{MKLROOT})
+# If environment variable MKL_ROOT is defined, it has the same effect as the cmake variable
+if( NOT MKL_ROOT AND DEFINED ENV{MKLROOT})
   if( EXISTS "$ENV{MKLROOT}/" )
-    set( MKLROOT $ENV{MKLROOT} )
+    set( MKL_ROOT $ENV{MKLROOT} )
   else()
-    message( "MKLROOT set to ${MKLROOT}, but folder does not exist")
+    message( "MKLROOT set to $ENV{MKLROOT}, but folder does not exist")
   endif()
+endif()
+
+if(${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "x86_64")
+    set(MKL_INTERFACE_LIBDIR "intel64")
+    set(MKL_INTERFACE_LIBNAME "mkl_intel_lp64")
+else()
+    set(MKL_INTERFACE_LIBDIR "ia32")
+    set(MKL_INTERFACE_LIBNAME "mkl_intel")
 endif()
 
 ################################### FFTWWrappers related ##################################
@@ -61,8 +69,8 @@ find_library(
 find_library(
   FFTWWrappers_GNU_LIBRARIES
   NAMES ${PREFERENCE_LIBRARY_PREFIX}fftw3xc_gnu${PREFERENCE_LIBRARY_SUFFIX} fftw3xc_gnu
-  PATHS ${MKLROOT}
-  PATH_SUFFIXES "lib/intel64_lin" "lib/intel64_mac" "lib/intel64"
+  PATHS ${MKL_ROOT}
+  PATH_SUFFIXES "lib/${MKL_INTERFACE_LIBDIR}_lin" "lib/${MKL_INTERFACE_LIBDIR}_mac" "lib/${MKL_INTERFACE_LIBDIR}"
   NO_DEFAULT_PATH
   )
 find_library(
@@ -84,8 +92,8 @@ find_library(
 find_library(
   FFTWWrappers_INTEL_LIBRARIES
   NAMES ${PREFERENCE_LIBRARY_PREFIX}fftw3xc_intel${PREFERENCE_LIBRARY_SUFFIX} fftw3xc_intel
-  PATHS ${MKLROOT}
-  PATH_SUFFIXES "lib/intel64_lin" "lib/intel64_mac" "lib/intel64_win" "lib/intel64"
+  PATHS ${MKL_ROOT}
+  PATH_SUFFIXES "lib/${MKL_INTERFACE_LIBDIR}_lin" "lib/${MKL_INTERFACE_LIBDIR}_mac" "lib/${MKL_INTERFACE_LIBDIR}_win" "lib/${MKL_INTERFACE_LIBDIR}"
   NO_DEFAULT_PATH
 )
 find_library(
@@ -107,8 +115,8 @@ find_library(
 find_library(
   FFTWWrappers_MSVS_LIBRARIES
   NAMES fftw3xc_msvs
-  PATHS ${MKLROOT}
-  PATH_SUFFIXES "lib/intel64_win" "lib/intel64"
+  PATHS ${MKL_ROOT}
+  PATH_SUFFIXES "lib/${MKL_INTERFACE_LIBDIR}_win" "lib/${MKL_INTERFACE_LIBDIR}"
   NO_DEFAULT_PATH
   )
 find_library(
@@ -125,7 +133,7 @@ endif()
 find_file(
   FFTWWrapper_include_file
   NAMES fftw3.h
-  PATHS ${MKLROOT} ${MKLROOT}/include/fftw
+  PATHS ${MKL_ROOT} ${MKL_ROOT}/include/fftw
   PATH_SUFFIXES "include" "include/fftw"
   NO_DEFAULT_PATH
   )
@@ -133,61 +141,61 @@ find_file(
 if(EXISTS ${FFTWWrapper_include_file})
   get_filename_component(FFTWWrappers_MKL_INCLUDE_DIR ${FFTWWrapper_include_file} DIRECTORY)
 else()
-  message( "FFTWWrappers was not able to find fftw3.h in ${MKLROOT}")
+  message( "FFTWWrappers was not able to find fftw3.h in ${MKL_ROOT}")
 endif()
 
 find_library(
-  MKL_INTEL_LP64
-  NAMES ${PREFERENCE_LIBRARY_PREFIX}mkl_intel_lp64${PREFERENCE_LIBRARY_SUFFIX} mkl_intel_lp64
-  PATHS ${MKLROOT}
-  PATH_SUFFIXES "lib" "lib/intel64_lin" "lib/intel64_mac" "lib/intel64_win" "lib/intel64"
+  MKL_INTEL
+  NAMES ${PREFERENCE_LIBRARY_PREFIX}${MKL_INTERFACE_LIBNAME}${PREFERENCE_LIBRARY_SUFFIX} ${MKL_INTERFACE_LIBNAME}
+  PATHS ${MKL_ROOT}
+  PATH_SUFFIXES "lib" "lib/${MKL_INTERFACE_LIBDIR}_lin" "lib/${MKL_INTERFACE_LIBDIR}_mac" "lib/${MKL_INTERFACE_LIBDIR}_win" "lib/${MKL_INTERFACE_LIBDIR}"
   NO_DEFAULT_PATH
   )
 
-if(EXISTS ${MKL_INTEL_LP64})
-  list(APPEND FFTWWrappers_MKL_LIBRARIES "${MKL_INTEL_LP64}")
+if(EXISTS ${MKL_INTEL})
+  list(APPEND FFTWWrappers_MKL_LIBRARIES "${MKL_INTEL}")
 else()
-  message( "FFTWWrappers was not able to find mkl_intel_lp64 in ${MKLROOT}")
+  message( "FFTWWrappers was not able to find ${MKL_INTERFACE_LIBNAME} in ${MKL_ROOT}")
 endif()
 
 find_library(
   MKL_INTEL_THREAD
   NAMES ${PREFERENCE_LIBRARY_PREFIX}mkl_intel_thread${PREFERENCE_LIBRARY_SUFFIX} mkl_intel_thread
-  PATHS ${MKLROOT}
-  PATH_SUFFIXES "lib" "lib/intel64_lin" "lib/intel64_mac" "lib/intel64_win" "lib/intel64"
+  PATHS ${MKL_ROOT}
+  PATH_SUFFIXES "lib" "lib/${MKL_INTERFACE_LIBDIR}_lin" "lib/${MKL_INTERFACE_LIBDIR}_mac" "lib/${MKL_INTERFACE_LIBDIR}_win" "lib/${MKL_INTERFACE_LIBDIR}"
   NO_DEFAULT_PATH
   )
 
 if(EXISTS ${MKL_INTEL_THREAD})
   list(APPEND FFTWWrappers_MKL_LIBRARIES "${MKL_INTEL_THREAD}")
 else()
-  message( "FFTWWrappers was not able to find mkl_intel_thread in ${MKLROOT}")
+  message( "FFTWWrappers was not able to find mkl_intel_thread in ${MKL_ROOT}")
 endif()
 
 find_library(
   MKL_CORE
   NAMES ${PREFERENCE_LIBRARY_PREFIX}mkl_core${PREFERENCE_LIBRARY_SUFFIX} mkl_core
-  PATHS ${MKLROOT}
-  PATH_SUFFIXES "lib" "lib/intel64_lin" "lib/intel64_mac" "lib/intel64_win" "lib/intel64"
+  PATHS ${MKL_ROOT}
+  PATH_SUFFIXES "lib" "lib/${MKL_INTERFACE_LIBDIR}_lin" "lib/${MKL_INTERFACE_LIBDIR}_mac" "lib/${MKL_INTERFACE_LIBDIR}_win" "lib/${MKL_INTERFACE_LIBDIR}"
   NO_DEFAULT_PATH
   )
 
 if(EXISTS ${MKL_CORE})
   list(APPEND FFTWWrappers_MKL_LIBRARIES "${MKL_CORE}")
 else()
-  message("FFTWWrappers was not able to find mkl_core in ${MKLROOT}")
+  message("FFTWWrappers was not able to find mkl_core in ${MKL_ROOT}")
 endif()
 
-list(APPEND FFTWWrappers_MKL_LIBRARY_DIRS "${MKLROOT}/../compiler/lib/intel64")
-list(APPEND FFTWWrappers_MKL_LIBRARY_DIRS "${MKLROOT}/../tbb/lib/intel64/gcc4.4")
+list(APPEND FFTWWrappers_MKL_LIBRARY_DIRS "${MKL_ROOT}/../compiler/lib/${MKL_INTERFACE_LIBDIR}")
+list(APPEND FFTWWrappers_MKL_LIBRARY_DIRS "${MKL_ROOT}/../tbb/lib/${MKL_INTERFACE_LIBDIR}/gcc4.4")
 
 # NOTE: According to Intel documentation, it is generally not recommended to
 # link against the static variants of the openMP libraries so we put them last:
 find_library(
   MKL_IOMP5
   NAMES iomp5 libiomp5.a libiomp5md
-  PATHS ${MKLROOT} ${MKLROOT}/../compiler ${MKLROOT}/../tbb
-  PATH_SUFFIXES "lib" "lib/intel64_lin" "lib/intel64_mac" "lib/intel64_win" "lib/intel64" "lib/intel64/gcc4.4"
+  PATHS ${MKL_ROOT} ${MKL_ROOT}/../compiler ${MKL_ROOT}/../tbb
+  PATH_SUFFIXES "lib" "lib/${MKL_INTERFACE_LIBDIR}_lin" "lib/${MKL_INTERFACE_LIBDIR}_mac" "lib/${MKL_INTERFACE_LIBDIR}_win" "lib/${MKL_INTERFACE_LIBDIR}" "lib/${MKL_INTERFACE_LIBDIR}/gcc4.4"
   NO_DEFAULT_PATH
   )
 

--- a/cmake/modules/FindFFTWWrappers.cmake
+++ b/cmake/modules/FindFFTWWrappers.cmake
@@ -4,19 +4,20 @@
 #   find_package(FFTWWrappers [REQUIRED] [QUIET])
 #
 # It sets the following variables:
-#   FFTWWrappers_FOUND          ... true if fftw is found on the system
-#   FFTWWrappers_GNU_LIBRARIES  ... list of library that were build with the GNU binary layout
-#   FFTWWrappers_INTEL_LIBRARIES  ... list of library that were build with the intel binary layout
-#   FFTWWrappers_LIBRARIES      ... list of library identifiers that were found (will be filled with serial/openmp/pthreads enabled file names if present, only stubs will be filled in not full paths)
-#   FFTWWrappers_MKL_LIBRARIES  ... list of library in the MKL that need to be linked to (intel64)
-#   FFTWWrappers_MKL_INCLUDE_DIR  ... folder containing fftw3.h
+#   FFTWWrappers_FOUND             ... true if fftw is found on the system
+#   FFTWWrappers_GNU_LIBRARIES     ... list of library that were build with the GNU binary layout
+#   FFTWWrappers_INTEL_LIBRARIES   ... list of library that were build with the intel binary layout
+#   FFTWWrappers_MSVS_LIBRARIES    ... list of library that were build with the MSVS binary layout
+#   FFTWWrappers_LIBRARIES         ... list of library identifiers that were found (will be filled with serial/openmp/pthreads enabled file names if present, only stubs will be filled in not full paths)
+#   FFTWWrappers_MKL_LIBRARIES     ... list of library in the MKL that need to be linked to (intel64)
+#   FFTWWrappers_MKL_INCLUDE_DIR   ... folder containing fftw3.h
 #   FFTWWrappers_MKL_LIBRARY_DIRS  ... folder containing the libraries in FFTWWrappers_MKL_LIBRARIES
-#   FFTWWrappers_LIBRARY_DIR	... fftw library directory
+#   FFTWWrappers_LIBRARY_DIR	   ... fftw library directory
 #
 # The following variables will be checked by the function
-#   FFTWWrappers_ROOT           ... if set, the libraries are exclusively searched
-#                                   under this path
-#   MKLROOT                     ... take the MKL libraries from here
+#   FFTWWrappers_ROOT              ... if set, the libraries are exclusively searched
+#                                      under this path
+#   MKLROOT                        ... take the MKL libraries from here
 #
 
 #If environment variable FFTWWrappers_ROOT is defined, it has the same effect as the cmake variable
@@ -42,21 +43,21 @@ endif()
 #initialize library variables
 find_library(
   FFTWWrappers_GNU_LIBRARIES
-  NAMES libfftw3xc_gnu libfftw3xc_gnu.a
+  NAMES fftw3xc_gnu fftw3xc_gnu.a
   PATHS ${FFTWWrappers_ROOT}
   PATH_SUFFIXES "lib" "lib64"
   NO_DEFAULT_PATH
   )
 find_library(
   FFTWWrappers_GNU_LIBRARIES
-  NAMES libfftw3xc_gnu libfftw3xc_gnu.a
+  NAMES fftw3xc_gnu fftw3xc_gnu.a
   PATHS ${MKLROOT}
-  PATH_SUFFIXES "lib/intel64"
+  PATH_SUFFIXES "lib/intel64_lin" "lib/intel64_mac" "lib/intel64"
   NO_DEFAULT_PATH
   )
 find_library(
   FFTWWrappers_GNU_LIBRARIES
-  NAMES libfftw3xc_gnu libfftw3xc_gnu.a
+  NAMES fftw3xc_gnu fftw3xc_gnu.a
   )
 
 if(EXISTS ${FFTWWrappers_GNU_LIBRARIES})
@@ -65,25 +66,48 @@ endif()
 
 find_library(
   FFTWWrappers_INTEL_LIBRARIES
-  NAMES libfftw3xc_intel libfftw3xc_intel.a
+  NAMES fftw3xc_intel fftw3xc_intel.a
   PATHS ${FFTWWrappers_ROOT}
   PATH_SUFFIXES "lib" "lib64"
   NO_DEFAULT_PATH
   )
 find_library(
   FFTWWrappers_INTEL_LIBRARIES
-  NAMES libfftw3xc_intel libfftw3xc_intel.a
+  NAMES fftw3xc_intel fftw3xc_intel.a
   PATHS ${MKLROOT}
-  PATH_SUFFIXES "lib/intel64_lin"
+  PATH_SUFFIXES "lib/intel64_lin" "lib/intel64_mac" "lib/intel64_win" "lib/intel64"
   NO_DEFAULT_PATH
 )
 find_library(
   FFTWWrappers_INTEL_LIBRARIES
-  NAMES libfftw3xc_intel libfftw3xc_intel.a
+  NAMES fftw3xc_intel fftw3xc_intel.a
 )
 
 if(EXISTS ${FFTWWrappers_INTEL_LIBRARIES})
   get_filename_component(FFTWWrappers_LIBRARY_DIR ${FFTWWrappers_INTEL_LIBRARIES} DIRECTORY)
+endif()
+
+find_library(
+  FFTWWrappers_MSVS_LIBRARIES
+  NAMES fftw3xc_msvs
+  PATHS ${FFTWWrappers_ROOT}
+  PATH_SUFFIXES "lib" "lib64"
+  NO_DEFAULT_PATH
+  )
+find_library(
+  FFTWWrappers_MSVS_LIBRARIES
+  NAMES fftw3xc_msvs
+  PATHS ${MKLROOT}
+  PATH_SUFFIXES "lib/intel64_win" "lib/intel64"
+  NO_DEFAULT_PATH
+  )
+find_library(
+  FFTWWrappers_MSVS_LIBRARIES
+  NAMES fftw3xc_msvs
+  )
+
+if(EXISTS ${FFTWWrappers_MSVS_LIBRARIES})
+  get_filename_component(FFTWWrappers_LIBRARY_DIR ${FFTWWrappers_MSVS_LIBRARIES} DIRECTORY)
 endif()
 
 ######################################### MKL related #####################################
@@ -104,44 +128,44 @@ endif()
 
 find_library(
   MKL_INTEL_LP64
-  NAMES libmkl_intel_lp64 libmkl_intel_lp64.a
+  NAMES mkl_intel_lp64 mkl_intel_lp64.a
   PATHS ${MKLROOT}
-  PATH_SUFFIXES "lib/intel64_lin" "lib/intel64"
+  PATH_SUFFIXES "lib" "lib/intel64_lin" "lib/intel64_mac" "lib/intel64_win" "lib/intel64"
   NO_DEFAULT_PATH
   )
 
 if(EXISTS ${MKL_INTEL_LP64})
   list(APPEND FFTWWrappers_MKL_LIBRARIES "${MKL_INTEL_LP64}")
 else()
-  message( "FFTWWrappers was not able to find libmkl_intel_lp64.a in ${MKLROOT}")
+  message( "FFTWWrappers was not able to find mkl_intel_lp64 in ${MKLROOT}")
 endif()
 
 find_library(
   MKL_INTEL_THREAD
-  NAMES libmkl_intel_thread libmkl_intel_thread.a
+  NAMES mkl_intel_thread mkl_intel_thread.a
   PATHS ${MKLROOT}
-  PATH_SUFFIXES "lib/intel64_lin" "lib/intel64"
+  PATH_SUFFIXES "lib" "lib/intel64_lin" "lib/intel64_mac" "lib/intel64_win" "lib/intel64"
   NO_DEFAULT_PATH
   )
 
 if(EXISTS ${MKL_INTEL_THREAD})
   list(APPEND FFTWWrappers_MKL_LIBRARIES "${MKL_INTEL_THREAD}")
 else()
-  message( "FFTWWrappers was not able to find libmkl_intel_thread.a in ${MKLROOT}")
+  message( "FFTWWrappers was not able to find mkl_intel_thread in ${MKLROOT}")
 endif()
 
 find_library(
   MKL_CORE
-  NAMES libmkl_core libmkl_core.a
+  NAMES mkl_core mkl_core.a
   PATHS ${MKLROOT}
-  PATH_SUFFIXES "lib/intel64_lin" "lib/intel64"
+  PATH_SUFFIXES "lib" "lib/intel64_lin" "lib/intel64_mac" "lib/intel64_win" "lib/intel64"
   NO_DEFAULT_PATH
   )
 
 if(EXISTS ${MKL_CORE})
   list(APPEND FFTWWrappers_MKL_LIBRARIES "${MKL_CORE}")
 else()
-  message("FFTWWrappers was not able to find libmkl_core.a in ${MKLROOT}")
+  message("FFTWWrappers was not able to find mkl_core in ${MKLROOT}")
 endif()
 
 list(APPEND FFTWWrappers_MKL_LIBRARY_DIRS "${MKLROOT}/../compiler/lib/intel64")
@@ -149,9 +173,9 @@ list(APPEND FFTWWrappers_MKL_LIBRARY_DIRS "${MKLROOT}/../tbb/lib/intel64/gcc4.4"
 
 find_library(
   MKL_IOMP5
-  NAMES iomp5 libiomp5 libiomp5.a
+  NAMES iomp5 libiomp5.a libiomp5md
   PATHS ${MKLROOT} ${MKLROOT}/../compiler ${MKLROOT}/../tbb
-  PATH_SUFFIXES "lib/intel64_lin" "lib/intel64" "lib/intel64/gcc4.4"
+  PATH_SUFFIXES "lib" "lib/intel64_lin" "lib/intel64_mac" "lib/intel64_win" "lib/intel64" "lib/intel64/gcc4.4"
   NO_DEFAULT_PATH
   )
 
@@ -161,12 +185,14 @@ else()
 
 endif()
 
-list(APPEND FFTWWrappers_MKL_LIBRARIES "m;dl")
+list(APPEND FFTWWrappers_MKL_LIBRARIES
+     $<$<NOT:$<C_COMPILER_ID:MSVC>>:m> "${CMAKE_DL_LIBS}")
 
 if(NOT FFTWWrappers_FIND_QUIETLY)
   message("++ FindFFTWWrappers")
   message("++ FFTWWrappers_GNU_LIBRARIES    : ${FFTWWrappers_GNU_LIBRARIES}")
   message("++ FFTWWrappers_INTEL_LIBRARIES  : ${FFTWWrappers_INTEL_LIBRARIES}")
+  message("++ FFTWWrappers_MSVS_LIBRARIES   : ${FFTWWrappers_MSVS_LIBRARIES}")
   message("++ FFTWWrappers_LIBRARY_DIR      : ${FFTWWrappers_LIBRARY_DIR}")
   message("++ FFTWWrappers_MKL_LIBRARIES    : ${FFTWWrappers_MKL_LIBRARIES}")
   message("++ FFTWWrappers_MKL_LIBRARY_DIRS : ${FFTWWrappers_MKL_LIBRARY_DIRS}")
@@ -185,15 +211,20 @@ if(FFTWWrappers_GNU_LIBRARIES)
     REQUIRED_VARS FFTWWrappers_MKL_INCLUDE_DIR
     )
   set(FFTWWrappers_LIBRARIES "${FFTWWrappers_GNU_LIBRARIES}")
-
-else()
+elseif(FFTWWrappers_INTEL_LIBRARIES)
   find_package_handle_standard_args(FFTWWrappers
     REQUIRED_VARS FFTWWrappers_INTEL_LIBRARIES
     REQUIRED_VARS FFTWWrappers_MKL_LIBRARIES
     REQUIRED_VARS FFTWWrappers_MKL_INCLUDE_DIR
     )
   set(FFTWWrappers_LIBRARIES "${FFTWWrappers_INTEL_LIBRARIES}")
-
+elseif(FFTWWrappers_MSVS_LIBRARIES)
+  find_package_handle_standard_args(FFTWWrappers
+    REQUIRED_VARS FFTWWrappers_MSVS_LIBRARIES
+    REQUIRED_VARS FFTWWrappers_MKL_LIBRARIES
+    REQUIRED_VARS FFTWWrappers_MKL_INCLUDE_DIR
+    )
+  set(FFTWWrappers_LIBRARIES "${FFTWWrappers_MSVS_LIBRARIES}")
 endif()
 
 
@@ -201,6 +232,7 @@ mark_as_advanced(
   FFTWWrappers_LIBRARIES
   FFTWWrappers_GNU_LIBRARIES
   FFTWWrappers_INTEL_LIBRARIES
+  FFTWWrappers_MSVS_LIBRARIES
   FFTWWrappers_LIBRARY_DIR
   FFTWWrappers_MKL_LIBRARIES
   FFTWWrappers_MKL_LIBRARY_DIR

--- a/inc/core/benchmark_data.hpp
+++ b/inc/core/benchmark_data.hpp
@@ -80,18 +80,12 @@ namespace gearshifft {
 
     template<bool Normalize>
     constexpr double sub(const ComplexVector& vector, size_t i) const {
-      if(Normalize)
-        return 1.0/size_ * (vector[i].real()) - static_cast<double>(data_linear_[i]);
-      else
-        return static_cast<double>( vector[i].real() - data_linear_[i] );
+      return Normalize ? 1.0/size_ * (vector[i].real()) - static_cast<double>(data_linear_[i]) : static_cast<double>( vector[i].real() - data_linear_[i] );
     }
 
     template<bool Normalize>
     constexpr double sub(const RealVector& vector, size_t i) const {
-      if(Normalize)
-        return 1.0/size_ * (vector[i]) - static_cast<double>(data_linear_[i]);
-      else
-        return static_cast<double>( vector[i] - data_linear_[i] );
+      return Normalize ? 1.0/size_ * (vector[i]) - static_cast<double>(data_linear_[i]) : static_cast<double>( vector[i] - data_linear_[i] );
     }
 
     void init_if_dim_changed(const Extent& extents) {

--- a/inc/core/traits.hpp
+++ b/inc/core/traits.hpp
@@ -35,7 +35,6 @@ namespace gearshifft {
   {
     typedef char one;
     typedef long two;
-    template <typename C> static one test( decltype(&C::title) ) ;
     template <typename C> static one test( decltype(&C::Title) ) ;
     template <typename C> static two test(...);
   public:


### PR DESCRIPTION
This PR fixes two minor issues:

1. Adds support for Intel MKL detection on 32bit platforms
2. Fixes the ill-named MKL_ROOT environment variable to MKLROOT
