### PR TITLE
Fixes uninitialized var, static libs, CLI options.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,7 +306,8 @@ if(GEARSHIFFT_BACKEND_FFTW)
     add_library(FFTW INTERFACE)
     add_library(gearshifft::FFTW ALIAS FFTW)
 
-    set(GEARSHIFFT_BACKEND_FFTW_THREADS 0)
+    # set initial value to 0
+    set(GEARSHIFFT_INTERNAL_FFTWX_THREADED 0)
 
     if(GEARSHIFFT_BACKEND_FFTW_OPENMP)
 
@@ -315,7 +316,7 @@ if(GEARSHIFFT_BACKEND_FFTW)
         find_and_add_openmp(FFTW ${_QUIET})
 
         if(TARGET OpenMP::OpenMP_CXX)
-          set(GEARSHIFFT_BACKEND_FFTW_THREADS 1)
+          set(GEARSHIFFT_INTERNAL_FFTWX_THREADED 1)
         else()
           message(WARNING "Could not find OpenMP")
           set(GEARSHIFFT_BACKEND_FFTW_OPENMP OFF)
@@ -330,7 +331,7 @@ if(GEARSHIFFT_BACKEND_FFTW)
     if(GEARSHIFFT_BACKEND_FFTW_PTHREADS)
       if(FFTW_THREADS_LIBS)
         find_package(Threads)
-        set(GEARSHIFFT_BACKEND_FFTW_THREADS 1)
+        set(GEARSHIFFT_INTERNAL_FFTWX_THREADED 1)
       else()
         message(WARNING "FFTW libraries for pthreads not found")
         set(GEARSHIFFT_BACKEND_FFTW_PTHREADS OFF)
@@ -348,7 +349,7 @@ if(GEARSHIFFT_BACKEND_FFTW)
       target_include_directories(FFTW INTERFACE ${FFTW_INCLUDE_DIR})
       target_compile_definitions(FFTW INTERFACE
         FFTW_ENABLED
-        GEARSHIFFT_BACKEND_FFTW_THREADS=${GEARSHIFFT_BACKEND_FFTW_THREADS})
+        GEARSHIFFT_INTERNAL_FFTWX_THREADED=${GEARSHIFFT_INTERNAL_FFTWX_THREADED})
       target_link_libraries(FFTW INTERFACE
         Common
         $<$<STREQUAL:${GEARSHIFFT_BACKEND_FFTW_OPENMP},ON>:${FFTW_OPENMP_LIBS}>
@@ -366,7 +367,11 @@ endif()
 #------------------------------------------------------------------------------
 
 if(GEARSHIFFT_BACKEND_FFTWWRAPPERS)
+  if(GEARSHIFFT_USE_STATIC_LIBS)
+    set(FFTWWrappers_USE_STATIC_LIBS ON) # otherwise find libs automatically
+  endif()
   find_package(FFTWWrappers ${_QUIET})
+
   if(FFTWWrappers_FOUND) # found FFTWWrappers for GNU or Intel
 
     if(FFTWWrappers_GNU_LIBRARIES AND NOT CMAKE_CXX_COMPILER_ID MATCHES "GNU"
@@ -378,19 +383,22 @@ if(GEARSHIFFT_BACKEND_FFTWWRAPPERS)
       add_library(gearshifft::FFTWWrappers ALIAS FFTWWrappers)
 
       # if compiler supports OpenMP then add flag, as FFTWWrappers might need it
+      # set initial value to 0
+      set(GEARSHIFFT_INTERNAL_FFTWX_THREADED 0)
+
       find_and_add_openmp(FFTWWrappers ${_QUIET})
 
       if(TARGET OpenMP::OpenMP_CXX)
-        set(GEARSHIFFT_BACKEND_FFTW_THREADS 1)
+        set(GEARSHIFFT_INTERNAL_FFTWX_THREADED 1)
       endif()
 
       target_include_directories(FFTWWrappers INTERFACE ${FFTWWrappers_MKL_INCLUDE_DIR})
       target_compile_definitions(FFTWWrappers INTERFACE
         FFTW_ENABLED
-        GEARSHIFFT_BACKEND_FFTW_THREADS=${GEARSHIFFT_BACKEND_FFTW_THREADS})
+        GEARSHIFFT_INTERNAL_FFTWX_THREADED=${GEARSHIFFT_INTERNAL_FFTWX_THREADED})
       target_link_libraries(FFTWWrappers INTERFACE
         Common
-        #      $<$<BOOL:${Threads_FOUND}>:Threads::Threads>
+        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:m>
         )
 
       if(FFTWWrappers_GNU_LIBRARIES)

--- a/cmake/gearshifft_options.cmake
+++ b/cmake/gearshifft_options.cmake
@@ -13,14 +13,15 @@ set_property(CACHE GEARSHIFFT_CXX11_ABI PROPERTY STRINGS "0;1")
 option(GEARSHIFFT_BACKEND_CUFFT "Compile gearshifft_cufft if possible" ON)
 option(GEARSHIFFT_BACKEND_CLFFT "Compile gearshifft_clfft if possible" ON)
 option(GEARSHIFFT_BACKEND_ROCFFT "Compile gearshifft_rocfft if possible (requires HCC as compiler)" ON)
+
 option(GEARSHIFFT_BACKEND_FFTW  "Compile gearshifft_fftw if possible" ON)
 cmake_dependent_option(
   GEARSHIFFT_BACKEND_FFTW_OPENMP "Use OpenMP parallel FFTW libraries if found" ON
   "GEARSHIFFT_BACKEND_FFTW" ON)
 cmake_dependent_option(
   GEARSHIFFT_BACKEND_FFTW_PTHREADS "Use pthreads parallel FFTW libraries if found" OFF
-   "GEARSHIFFT_BACKEND_FFTW" ON
-  )
+  "GEARSHIFFT_BACKEND_FFTW" ON)
+
 option(GEARSHIFFT_BACKEND_FFTWWRAPPERS  "Compile gearshifft_fftwwrappers if possible" ON)
 
 # backend-disabler

--- a/cmake/modules/FindFFTW.cmake
+++ b/cmake/modules/FindFFTW.cmake
@@ -2,16 +2,16 @@
 #
 # Usage:
 #   find_package(FFTW [REQUIRED] [QUIET] [COMPONENTS ...])
-#     
+#
 # It sets the following variables:
 #   FFTW_FOUND          ... true if fftw is found on the system
 #   FFTW_LIBRARIES      ... list of library identifiers that were found (will be filled with serial/openmp/pthreads enabled file names if present, only stubs will be filled in not full paths)
 #   FFTW_INCLUDES       ... fftw include directory
-#   FFTW_SERIAL_LIBS	... list of full path(s) to serial fftw library(ies)
-#   FFTW_THREADS_LIBS	... list of full path(s) to pthreads fftw library(ies)
-#   FFTW_OPENMP_LIBS	... list of full path(s) to openmp fftw library(ies)
-#   FFTW_INCLUDE_DIR	... fftw include directory
-#   FFTW_LIBRARY_DIR	... fftw library directory
+#   FFTW_SERIAL_LIBS  ... list of full path(s) to serial fftw library(ies)
+#   FFTW_THREADS_LIBS ... list of full path(s) to pthreads fftw library(ies)
+#   FFTW_OPENMP_LIBS  ... list of full path(s) to openmp fftw library(ies)
+#   FFTW_INCLUDE_DIR  ... fftw include directory
+#   FFTW_LIBRARY_DIR  ... fftw library directory
 #
 # The following variables will be checked by the function
 #   FFTW_USE_STATIC_LIBS    ... if true, only static libraries are found
@@ -60,12 +60,12 @@ endforeach()
 
 #If environment variable FFTWDIR is specified, it has same effect as FFTW_ROOT
 if( NOT FFTW_ROOT AND (DEFINED ENV{FFTWDIR} OR DEFINED ENV{FFTW_ROOT}))
-  if(EXISTS "$ENV{FFTWDIR}/")                                          
-    set( FFTW_ROOT $ENV{FFTWDIR} )                                     
-  endif()                                                              
-  if( EXISTS "$ENV{FFTW_ROOT}/" )                                      
-    set( FFTW_ROOT $ENV{FFTW_ROOT} )                                   
-  endif()                                                              
+  if(EXISTS "$ENV{FFTWDIR}/")
+    set( FFTW_ROOT $ENV{FFTWDIR} )
+  endif()
+  if( EXISTS "$ENV{FFTW_ROOT}/" )
+    set( FFTW_ROOT $ENV{FFTW_ROOT} )
+  endif()
 endif()
 
 # Check if we can use PkgConfig
@@ -79,17 +79,15 @@ endif()
 #Check whether to search static or dynamic libs
 set( CMAKE_FIND_LIBRARY_SUFFIXES_SAV ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 
-if( ${FFTW_USE_STATIC_LIBS} )
+if( FFTW_USE_STATIC_LIBS ) # find static libs only
   set( CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_STATIC_LIBRARY_SUFFIX} )
-else()
-  set( CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_SHARED_LIBRARY_SUFFIX} )
 endif()
 
 #initialize library variables
 foreach(_LIBSTUB IN LISTS FFTW_LIBRARY_STUBS)
-  
+
   if( FFTW_ROOT )
-    
+
     find_library(
       FFTW_SERIAL_STUBLIB
       NAMES ${_LIBSTUB} lib${_LIBSTUB}
@@ -113,7 +111,7 @@ foreach(_LIBSTUB IN LISTS FFTW_LIBRARY_STUBS)
       PATH_SUFFIXES "lib" "lib64"
       NO_DEFAULT_PATH
       )
-    
+
   else( FFTW_ROOT )
     find_library(
       FFTW_SERIAL_STUBLIB
@@ -133,9 +131,10 @@ foreach(_LIBSTUB IN LISTS FFTW_LIBRARY_STUBS)
       NAMES ${_LIBSTUB}_threads lib${_LIBSTUB}_threads
       PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
       )
-    
+
   endif( FFTW_ROOT )
 
+  # manually build shared libs from static libs (if only static libs were found)
   if(EXISTS ${FFTW_SERIAL_STUBLIB})
 
     if( NOT CMAKE_FIND_LIBRARY_SUFFIXES MATCHES ${CMAKE_STATIC_LIBRARY_SUFFIX} )
@@ -168,7 +167,7 @@ foreach(_LIBSTUB IN LISTS FFTW_LIBRARY_STUBS)
 
     list(APPEND FFTW_OPENMP_LIBS_ABSPATH ${FFTW_OPENMP_STUBLIB})
     list(APPEND FFTW_OPENMP_LIBS ${_LIBSTUB}_omp)
-    
+
     list(APPEND FFTW_LIBRARIES ${_LIBSTUB}_omp)
 
   else()
@@ -187,7 +186,7 @@ foreach(_LIBSTUB IN LISTS FFTW_LIBRARY_STUBS)
 
     list(APPEND FFTW_THREADS_LIBS_ABSPATH ${FFTW_THREADS_STUBLIB})
     list(APPEND FFTW_THREADS_LIBS ${_LIBSTUB}_threads)
-    
+
     list(APPEND FFTW_LIBRARIES ${_LIBSTUB}_threads)
   else()
     if(NOT FFTW_FIND_QUIETLY)
@@ -198,12 +197,12 @@ foreach(_LIBSTUB IN LISTS FFTW_LIBRARY_STUBS)
   unset(FFTW_SERIAL_STUBLIB CACHE)
   unset(FFTW_THREADS_STUBLIB CACHE)
   unset(FFTW_OPENMP_STUBLIB CACHE)
-  
+
 endforeach()
 
 #find includes
 if( FFTW_ROOT )
-  
+
   find_path(
     FFTW_INCLUDES
     NAMES "fftw3.h"
@@ -247,7 +246,7 @@ include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(FFTW DEFAULT_MSG
   FFTW_INCLUDES
   FFTW_LIBRARIES
-#  HANDLE_COMPONENTS
+  #  HANDLE_COMPONENTS
   )
 
 if(NOT FFTW_FIND_QUIETLY)
@@ -255,7 +254,7 @@ if(NOT FFTW_FIND_QUIETLY)
   message("++ FFTW_INCLUDES    : ${FFTW_INCLUDES}")
   message("++ FFTW_LIBRARIES   : ${FFTW_LIBRARIES}")
   message("++ FFTW_SERIAL_LIBS : ${FFTW_SERIAL_LIBS_ABSPATH}")
-  message("++ FFTW_THREADS_LIBS: ${FFTW_THREADS_LIBS_ABSPATH}") 
+  message("++ FFTW_THREADS_LIBS: ${FFTW_THREADS_LIBS_ABSPATH}")
   message("++ FFTW_OPENMP_LIBS : ${FFTW_OPENMP_LIBS_ABSPATH}")
   message("++ FFTW_INCLUDE_DIR : ${FFTW_INCLUDE_DIR}")
   message("++ FFTW_LIBRARY_DIR : ${FFTW_LIBRARY_DIR}")
@@ -270,4 +269,3 @@ mark_as_advanced(
   FFTW_INCLUDE_DIR
   FFTW_LIBRARY_DIR
   )
-

--- a/cmake/modules/FindFFTWWrappers.cmake
+++ b/cmake/modules/FindFFTWWrappers.cmake
@@ -1,33 +1,31 @@
-# - Find the FFTW library
+# - Find the MKL libraries for FFTWWrappers
 #
 # Usage:
 #   find_package(FFTWWrappers [REQUIRED] [QUIET])
 #
 # It sets the following variables:
-#   FFTWWrappers_FOUND             ... true if fftw is found on the system
+#   FFTWWrappers_FOUND             ... true if FFTWWrappers/MKL is found on the system
 #   FFTWWrappers_GNU_LIBRARIES     ... list of library that were build with the GNU binary layout
 #   FFTWWrappers_INTEL_LIBRARIES   ... list of library that were build with the intel binary layout
 #   FFTWWrappers_MSVS_LIBRARIES    ... list of library that were build with the MSVS binary layout
 #   FFTWWrappers_LIBRARIES         ... list of library identifiers that were found (will be filled with serial/openmp/pthreads enabled file names if present, only stubs will be filled in not full paths)
 #   FFTWWrappers_MKL_LIBRARIES     ... list of library in the MKL that need to be linked to
 #   FFTWWrappers_MKL_INCLUDE_DIR   ... folder containing fftw3.h
-#   FFTWWrappers_MKL_LIBRARY_DIRS  ... folder containing the libraries in FFTWWrappers_MKL_LIBRARIES
-#   FFTWWrappers_LIBRARY_DIR	   ... fftw library directory
+#   FFTWWrappers_LIBRARY_DIR       ... library directory
 #
 # The following variables will be checked by the function
+#   FFTWWrappers_USE_STATIC_LIBS   ... if true, only static libraries are found
 #   FFTWWrappers_ROOT              ... if set, the libraries are exclusively searched
 #                                      under this path
-#   MKL_ROOT                       ... take the MKL libraries from here
+#   MKLROOT                        ... take the MKL libraries from here
 #
 
-if(GEARSHIFFT_USE_STATIC_LIBS)
-  set(PREFERENCE_LIBRARY_PREFIX "${CMAKE_STATIC_LIBRARY_PREFIX}")
-  set(PREFERENCE_LIBRARY_SUFFIX "${CMAKE_STATIC_LIBRARY_SUFFIX}")
-  message("FFTWWrappers will prefer libraries with prefix '${PREFERENCE_LIBRARY_PREFIX}' and suffix '${PREFERENCE_LIBRARY_SUFFIX}'")
-else()
-  set(PREFERENCE_LIBRARY_PREFIX)
-  set(PREFERENCE_LIBRARY_SUFFIX)
-  message("FFTWWrappers will prefer libraries with no prefix and no suffix")
+
+#Check whether to search static or dynamic libs
+set( CMAKE_FIND_LIBRARY_SUFFIXES_SAV ${CMAKE_FIND_LIBRARY_SUFFIXES} )
+
+if( FFTWWrappers_USE_STATIC_LIBS ) # find static libs only
+  set( CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_STATIC_LIBRARY_SUFFIX} )
 endif()
 
 # If environment variable FFTWWrappers_ROOT is defined, it has the same effect as the cmake variable
@@ -44,38 +42,42 @@ if( NOT MKL_ROOT AND DEFINED ENV{MKLROOT})
   if( EXISTS "$ENV{MKLROOT}/" )
     set( MKL_ROOT $ENV{MKLROOT} )
   else()
-    message( "MKLROOT set to $ENV{MKLROOT}, but folder does not exist")
+    message( "MKL_ROOT set to $ENV{MKLROOT}, but folder does not exist")
   endif()
 endif()
 
 if(${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "x86_64")
-    set(MKL_INTERFACE_LIBDIR "intel64")
-    set(MKL_INTERFACE_LIBNAME "mkl_intel_lp64")
+  set(MKL_INTERFACE_LIBDIR "intel64")
+  set(MKL_INTERFACE_LIBNAME "mkl_intel_lp64") # index integers might be 32bit though
 else()
-    set(MKL_INTERFACE_LIBDIR "ia32")
-    set(MKL_INTERFACE_LIBNAME "mkl_intel")
+  set(MKL_INTERFACE_LIBDIR "ia32")
+  set(MKL_INTERFACE_LIBNAME "mkl_intel")
 endif()
 
 ################################### FFTWWrappers related ##################################
+# see: http://geco.mines.edu/files/userguides/techReports/mklWrappers/
+set(_LIBSTUB_GNU "fftw3xc_gnu")
+set(_LIBSTUB_INTEL "fftw3xc_intel")
+set(_LIBSTUB_MSVS "fftw3xc_msvs")
 
 #initialize library variables
 find_library(
   FFTWWrappers_GNU_LIBRARIES
-  NAMES ${PREFERENCE_LIBRARY_PREFIX}fftw3xc_gnu${PREFERENCE_LIBRARY_SUFFIX} fftw3xc_gnu
+  NAMES ${_LIBSTUB_GNU}
   PATHS ${FFTWWrappers_ROOT}
   PATH_SUFFIXES "lib" "lib64"
   NO_DEFAULT_PATH
   )
 find_library(
   FFTWWrappers_GNU_LIBRARIES
-  NAMES ${PREFERENCE_LIBRARY_PREFIX}fftw3xc_gnu${PREFERENCE_LIBRARY_SUFFIX} fftw3xc_gnu
+  NAMES ${_LIBSTUB_GNU}
   PATHS ${MKL_ROOT}
-  PATH_SUFFIXES "lib/${MKL_INTERFACE_LIBDIR}_lin" "lib/${MKL_INTERFACE_LIBDIR}_mac" "lib/${MKL_INTERFACE_LIBDIR}"
+  PATH_SUFFIXES "lib" "lib/${MKL_INTERFACE_LIBDIR}_lin" "lib/${MKL_INTERFACE_LIBDIR}_mac" "lib/${MKL_INTERFACE_LIBDIR}"
   NO_DEFAULT_PATH
   )
 find_library(
   FFTWWrappers_GNU_LIBRARIES
-  NAMES ${PREFERENCE_LIBRARY_PREFIX}fftw3xc_gnu${PREFERENCE_LIBRARY_SUFFIX} fftw3xc_gnu
+  NAMES ${_LIBSTUB_GNU}
   )
 
 if(EXISTS ${FFTWWrappers_GNU_LIBRARIES})
@@ -84,22 +86,22 @@ endif()
 
 find_library(
   FFTWWrappers_INTEL_LIBRARIES
-  NAMES ${PREFERENCE_LIBRARY_PREFIX}fftw3xc_intel${PREFERENCE_LIBRARY_SUFFIX} fftw3xc_intel
+  NAMES ${_LIBSTUB_INTEL}
   PATHS ${FFTWWrappers_ROOT}
   PATH_SUFFIXES "lib" "lib64"
   NO_DEFAULT_PATH
   )
 find_library(
   FFTWWrappers_INTEL_LIBRARIES
-  NAMES ${PREFERENCE_LIBRARY_PREFIX}fftw3xc_intel${PREFERENCE_LIBRARY_SUFFIX} fftw3xc_intel
+  NAMES ${_LIBSTUB_INTEL}
   PATHS ${MKL_ROOT}
-  PATH_SUFFIXES "lib/${MKL_INTERFACE_LIBDIR}_lin" "lib/${MKL_INTERFACE_LIBDIR}_mac" "lib/${MKL_INTERFACE_LIBDIR}_win" "lib/${MKL_INTERFACE_LIBDIR}"
+  PATH_SUFFIXES "lib" "lib/${MKL_INTERFACE_LIBDIR}_lin" "lib/${MKL_INTERFACE_LIBDIR}_mac" "lib/${MKL_INTERFACE_LIBDIR}_win" "lib/${MKL_INTERFACE_LIBDIR}"
   NO_DEFAULT_PATH
-)
+  )
 find_library(
   FFTWWrappers_INTEL_LIBRARIES
-  NAMES ${PREFERENCE_LIBRARY_PREFIX}fftw3xc_intel${PREFERENCE_LIBRARY_SUFFIX} fftw3xc_intel
-)
+  NAMES ${_LIBSTUB_INTEL}
+  )
 
 if(EXISTS ${FFTWWrappers_INTEL_LIBRARIES})
   get_filename_component(FFTWWrappers_LIBRARY_DIR ${FFTWWrappers_INTEL_LIBRARIES} DIRECTORY)
@@ -107,21 +109,21 @@ endif()
 
 find_library(
   FFTWWrappers_MSVS_LIBRARIES
-  NAMES fftw3xc_msvs
+  NAMES ${_LIBSTUB_MSVS}
   PATHS ${FFTWWrappers_ROOT}
   PATH_SUFFIXES "lib" "lib64"
   NO_DEFAULT_PATH
   )
 find_library(
   FFTWWrappers_MSVS_LIBRARIES
-  NAMES fftw3xc_msvs
+  NAMES ${_LIBSTUB_MSVS}
   PATHS ${MKL_ROOT}
   PATH_SUFFIXES "lib/${MKL_INTERFACE_LIBDIR}_win" "lib/${MKL_INTERFACE_LIBDIR}"
   NO_DEFAULT_PATH
   )
 find_library(
   FFTWWrappers_MSVS_LIBRARIES
-  NAMES fftw3xc_msvs
+  NAMES ${_LIBSTUB_MSVS}
   )
 
 if(EXISTS ${FFTWWrappers_MSVS_LIBRARIES})
@@ -132,7 +134,7 @@ endif()
 
 find_file(
   FFTWWrapper_include_file
-  NAMES fftw3.h
+  NAMES "fftw3.h"
   PATHS ${MKL_ROOT} ${MKL_ROOT}/include/fftw
   PATH_SUFFIXES "include" "include/fftw"
   NO_DEFAULT_PATH
@@ -141,12 +143,14 @@ find_file(
 if(EXISTS ${FFTWWrapper_include_file})
   get_filename_component(FFTWWrappers_MKL_INCLUDE_DIR ${FFTWWrapper_include_file} DIRECTORY)
 else()
-  message( "FFTWWrappers was not able to find fftw3.h in ${MKL_ROOT}")
+  if(NOT FFTWWrappers_FIND_QUIETLY)
+    message( "FFTWWrappers was not able to find fftw3.h in ${MKL_ROOT}")
+  endif()
 endif()
 
 find_library(
   MKL_INTEL
-  NAMES ${PREFERENCE_LIBRARY_PREFIX}${MKL_INTERFACE_LIBNAME}${PREFERENCE_LIBRARY_SUFFIX} ${MKL_INTERFACE_LIBNAME}
+  NAMES ${MKL_INTERFACE_LIBNAME}
   PATHS ${MKL_ROOT}
   PATH_SUFFIXES "lib" "lib/${MKL_INTERFACE_LIBDIR}_lin" "lib/${MKL_INTERFACE_LIBDIR}_mac" "lib/${MKL_INTERFACE_LIBDIR}_win" "lib/${MKL_INTERFACE_LIBDIR}"
   NO_DEFAULT_PATH
@@ -155,12 +159,14 @@ find_library(
 if(EXISTS ${MKL_INTEL})
   list(APPEND FFTWWrappers_MKL_LIBRARIES "${MKL_INTEL}")
 else()
-  message( "FFTWWrappers was not able to find ${MKL_INTERFACE_LIBNAME} in ${MKL_ROOT}")
+  if(NOT FFTWWrappers_FIND_QUIETLY)
+    message( "FFTWWrappers was not able to find ${MKL_INTERFACE_LIBNAME} in ${MKL_ROOT}")
+  endif()
 endif()
 
 find_library(
   MKL_INTEL_THREAD
-  NAMES ${PREFERENCE_LIBRARY_PREFIX}mkl_intel_thread${PREFERENCE_LIBRARY_SUFFIX} mkl_intel_thread
+  NAMES "mkl_intel_thread"
   PATHS ${MKL_ROOT}
   PATH_SUFFIXES "lib" "lib/${MKL_INTERFACE_LIBDIR}_lin" "lib/${MKL_INTERFACE_LIBDIR}_mac" "lib/${MKL_INTERFACE_LIBDIR}_win" "lib/${MKL_INTERFACE_LIBDIR}"
   NO_DEFAULT_PATH
@@ -169,12 +175,14 @@ find_library(
 if(EXISTS ${MKL_INTEL_THREAD})
   list(APPEND FFTWWrappers_MKL_LIBRARIES "${MKL_INTEL_THREAD}")
 else()
-  message( "FFTWWrappers was not able to find mkl_intel_thread in ${MKL_ROOT}")
+  if(NOT FFTWWrappers_FIND_QUIETLY)
+    message( "FFTWWrappers was not able to find mkl_intel_thread in ${MKL_ROOT}")
+  endif()
 endif()
 
 find_library(
   MKL_CORE
-  NAMES ${PREFERENCE_LIBRARY_PREFIX}mkl_core${PREFERENCE_LIBRARY_SUFFIX} mkl_core
+  NAMES "mkl_core"
   PATHS ${MKL_ROOT}
   PATH_SUFFIXES "lib" "lib/${MKL_INTERFACE_LIBDIR}_lin" "lib/${MKL_INTERFACE_LIBDIR}_mac" "lib/${MKL_INTERFACE_LIBDIR}_win" "lib/${MKL_INTERFACE_LIBDIR}"
   NO_DEFAULT_PATH
@@ -183,44 +191,46 @@ find_library(
 if(EXISTS ${MKL_CORE})
   list(APPEND FFTWWrappers_MKL_LIBRARIES "${MKL_CORE}")
 else()
-  message("FFTWWrappers was not able to find mkl_core in ${MKL_ROOT}")
+  if(NOT FFTWWrappers_FIND_QUIETLY)
+    message("FFTWWrappers was not able to find mkl_core in ${MKL_ROOT}")
+  endif()
 endif()
 
-list(APPEND FFTWWrappers_MKL_LIBRARY_DIRS "${MKL_ROOT}/../compiler/lib/${MKL_INTERFACE_LIBDIR}")
-list(APPEND FFTWWrappers_MKL_LIBRARY_DIRS "${MKL_ROOT}/../tbb/lib/${MKL_INTERFACE_LIBDIR}/gcc4.4")
 
-# NOTE: According to Intel documentation, it is generally not recommended to
-# link against the static variants of the openMP libraries so we put them last:
+
 find_library(
   MKL_IOMP5
-  NAMES iomp5 libiomp5.a libiomp5md
+  NAMES "iomp5" "iomp5md"
   PATHS ${MKL_ROOT} ${MKL_ROOT}/../compiler ${MKL_ROOT}/../tbb
-  PATH_SUFFIXES "lib" "lib/${MKL_INTERFACE_LIBDIR}_lin" "lib/${MKL_INTERFACE_LIBDIR}_mac" "lib/${MKL_INTERFACE_LIBDIR}_win" "lib/${MKL_INTERFACE_LIBDIR}" "lib/${MKL_INTERFACE_LIBDIR}/gcc4.4"
+  PATH_SUFFIXES "lib" "lib/${MKL_INTERFACE_LIBDIR}_lin" "lib/${MKL_INTERFACE_LIBDIR}_mac" "lib/${MKL_INTERFACE_LIBDIR}_win" "lib/${MKL_INTERFACE_LIBDIR}" "lib/${MKL_INTERFACE_LIBDIR}/gcc4.7" "lib/${MKL_INTERFACE_LIBDIR}/gcc4.4" "lib/${MKL_INTERFACE_LIBDIR}/gcc4.1"
   NO_DEFAULT_PATH
   )
 
 if(EXISTS ${MKL_IOMP5})
   list(APPEND FFTWWrappers_MKL_LIBRARIES "${MKL_IOMP5}")
 else()
-
+  if(NOT FFTWWrappers_FIND_QUIETLY)
+    message("FFTWWrappers was not able to find iomp5")
+  endif()
 endif()
 
-list(APPEND FFTWWrappers_MKL_LIBRARIES
-     $<$<NOT:$<C_COMPILER_ID:MSVC>>:m> "${CMAKE_DL_LIBS}")
 
 if(NOT FFTWWrappers_FIND_QUIETLY)
   message("++ FindFFTWWrappers")
+  message("++ FFTWWrappers_ROOT             : ${FFTWWrappers_ROOT}")
+  message("++ MKL_ROOT                      : ${MKL_ROOT}")
   message("++ FFTWWrappers_GNU_LIBRARIES    : ${FFTWWrappers_GNU_LIBRARIES}")
   message("++ FFTWWrappers_INTEL_LIBRARIES  : ${FFTWWrappers_INTEL_LIBRARIES}")
   message("++ FFTWWrappers_MSVS_LIBRARIES   : ${FFTWWrappers_MSVS_LIBRARIES}")
   message("++ FFTWWrappers_LIBRARY_DIR      : ${FFTWWrappers_LIBRARY_DIR}")
   message("++ FFTWWrappers_MKL_LIBRARIES    : ${FFTWWrappers_MKL_LIBRARIES}")
-  message("++ FFTWWrappers_MKL_LIBRARY_DIRS : ${FFTWWrappers_MKL_LIBRARY_DIRS}")
   message("++ FFTWWrappers_MKL_INCLUDE_DIR  : ${FFTWWrappers_MKL_INCLUDE_DIR}")
 endif()
 
 
 ######################################### EXPORTS #####################################
+#revert CMAKE_FIND_LIBRARY_SUFFIXES
+set( CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES_SAV} )
 
 include(FindPackageHandleStandardArgs)
 
@@ -257,4 +267,4 @@ mark_as_advanced(
   FFTWWrappers_MKL_LIBRARIES
   FFTWWrappers_MKL_LIBRARY_DIR
   FFTWWrappers_MKL_INCLUDE_DIR
-)
+  )


### PR DESCRIPTION
- cmake: `GEARSHIFFT_BACKEND_FFTW_THREADS` -> `GEARSHIFFT_INTERNAL_FFTWX_THREADED`
- FFTWWrappers/MKL does not implement parameters for rigor & timelimit
  - so do not show CLI options for that
- Fixes and moves non-MKL libs in MKL cmake variable.
- show messages only when not set to quiet (FindFFTWWrappers.cmake)
- Only restrict suffix for static libs (also in FindFFTW.cmake)

@emmenlau Can you test this PR on your systems? I changed some logic from your recent PRs.
edit: refers to #140 