### PR TITLE
Suppresses gcc warnings only for boost includes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,17 +109,10 @@ target_compile_options(Common INTERFACE
   $<$<CXX_COMPILER_ID:GNU>:$<BUILD_INTERFACE:-Wextra>>
   $<$<CXX_COMPILER_ID:GNU>:$<BUILD_INTERFACE:-Wold-style-cast>>
 #  $<$<CXX_COMPILER_ID:GNU>:$<BUILD_INTERFACE:-Wshadow>> # maybe too many false positives
-  $<$<CXX_COMPILER_ID:GNU>:-Wno-missing-braces>
-  $<$<CXX_COMPILER_ID:GNU>:-Wno-deprecated-declarations>
-  $<$<CXX_COMPILER_ID:GNU>:-Wno-ignored-attributes>
-  $<$<CXX_COMPILER_ID:GNU>:-Wno-unused-local-typedefs>
   # Clang
   $<$<CXX_COMPILER_ID:Clang>:$<BUILD_INTERFACE:-Wall>>
   $<$<CXX_COMPILER_ID:Clang>:$<BUILD_INTERFACE:-Wextra>>
   $<$<CXX_COMPILER_ID:Clang>:$<BUILD_INTERFACE:-Wshadow>> # see above, does better job than gcc
-  $<$<CXX_COMPILER_ID:Clang>:-Wno-missing-braces>
-  $<$<CXX_COMPILER_ID:Clang>:-Wno-deprecated-declarations>
-  $<$<CXX_COMPILER_ID:Clang>:-Wno-ignored-attributes>
   # MSVC
   $<$<CXX_COMPILER_ID:MSVC>:/bigobj>
   $<$<CXX_COMPILER_ID:MSVC>:/wd4003>

--- a/inc/core/application.hpp
+++ b/inc/core/application.hpp
@@ -8,7 +8,11 @@
 
 #include "gearshifft_version.hpp"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <boost/asio.hpp>
+#pragma GCC diagnostic pop
 
 #include <ctime>
 #include <vector>

--- a/inc/core/benchmark_data.hpp
+++ b/inc/core/benchmark_data.hpp
@@ -4,10 +4,15 @@
 #include "types.hpp"
 
 // http://www.boost.org/doc/libs/1_56_0/doc/html/align/tutorial.html
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <boost/align/aligned_allocator.hpp>
 #include <boost/range/counting_range.hpp>
 #include <boost/container/vector.hpp>
 #include <boost/noncopyable.hpp>
+#pragma GCC diagnostic pop
 
 #include <numeric>
 #include <vector>

--- a/inc/core/benchmark_executor.hpp
+++ b/inc/core/benchmark_executor.hpp
@@ -7,7 +7,11 @@
 #include "benchmark_data.hpp"
 #include "types.hpp"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <boost/test/included/unit_test.hpp> // Single-header usage variant
+#pragma GCC diagnostic pop
 
 #include <type_traits>
 #include <cmath>

--- a/inc/core/options.hpp
+++ b/inc/core/options.hpp
@@ -2,8 +2,11 @@
 #define OPTIONS_HPP_
 
 #include "types.hpp"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
 #include <boost/program_options.hpp>
 #include <boost/core/noncopyable.hpp>
+#pragma GCC diagnostic pop
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
- gcc warnings old-style-cast and unused-parameter are suppressed for
  boost includes