### PR TITLE
Fixes for modern compilers and libraries

### DIFF
--- a/cmake/modules/FindARMPL.cmake
+++ b/cmake/modules/FindARMPL.cmake
@@ -40,7 +40,7 @@ add_library(ARMPL::ARMPL INTERFACE IMPORTED)
 set_target_properties(ARMPL::ARMPL
   PROPERTIES INTERFACE_COMPILE_DEFINITIONS INTEGER32
              INTERFACE_INCLUDE_DIRECTORIES "${ARMPL_INCLUDE_DIRS}"
-             INTERFACE_LINK_LIBRARIES "${ARMPL_LIBRARIES};OpenMP::OpenMP_CXX"
+             INTERFACE_LINK_LIBRARIES "${ARMPL_LIBRARIES};$<$<CXX_COMPILER_ID:GNU>:gfortran>;OpenMP::OpenMP_CXX"
 )
 
 #------------------------------------------------------------------------------

--- a/inc/core/benchmark_suite.hpp
+++ b/inc/core/benchmark_suite.hpp
@@ -8,7 +8,7 @@
 
 #include <array>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <boost/test/included/unit_test.hpp> // Single-header usage variant
 #include <boost/test/unit_test_suite.hpp>

--- a/inc/core/types.hpp
+++ b/inc/core/types.hpp
@@ -11,12 +11,13 @@
 
 #include <boost/mpl/list.hpp>
 
-#include <array>
-#include <vector>
-#include <iostream>
 #include <algorithm>
+#include <array>
 #include <complex>
+#include <iostream>
+#include <limits>
 #include <type_traits>
+#include <vector>
 
 namespace gearshifft {
   using Extents1D = std::array<size_t,1>;

--- a/inc/libraries/clfft/clfft_helper.hpp
+++ b/inc/libraries/clfft/clfft_helper.hpp
@@ -1,6 +1,8 @@
 #ifndef CLFFT_HELPER_HPP_
 #define CLFFT_HELPER_HPP_
 
+#define CL_TARGET_OPENCL_VERSION 120
+
 #include <CL/cl.h>
 #include <clFFT.h>
 #include <stdexcept>

--- a/inc/libraries/fftw/fftw.hpp
+++ b/inc/libraries/fftw/fftw.hpp
@@ -470,7 +470,7 @@ namespace fftw {
       std::stringstream ss;
       std::string line;
       ifs.open(filename.c_str(), std::ifstream::in);
-      if(ifs.good()==false)
+      if(!ifs.good())
         throw std::runtime_error("Wisdom file not accessable.");
 
       if(ifs.is_open()) {
@@ -524,7 +524,7 @@ namespace fftw {
     static constexpr
     bool IsComplex = TFFT::IsComplex;
     static constexpr
-    bool IsInplaceReal = IsInplace && IsComplex==false;
+    bool IsInplaceReal = IsInplace && !IsComplex;
 
     using value_type  = typename std::conditional<IsComplex,ComplexType,RealType>::type;
 
@@ -559,7 +559,7 @@ namespace fftw {
                              1,
                              std::multiplies<std::size_t>());
 
-        if(IsComplex==false){
+        if(!IsComplex){
           extents_complex_.back() = (extents_.back()/2 + 1);
         }
 
@@ -569,7 +569,7 @@ namespace fftw {
                                      std::multiplies<size_t>());
 
         data_size_ = (IsInplaceReal ? 2*n_complex_ : n_) * sizeof(value_type);
-        if(IsInplace==false)
+        if(!IsInplace)
           data_complex_size_ = n_complex_ * sizeof(ComplexType);
 
         //size_t total_mem = getMemorySize();

--- a/inc/libraries/fftw/fftw.hpp
+++ b/inc/libraries/fftw/fftw.hpp
@@ -11,12 +11,14 @@
 #include "core/get_memory_size.hpp"
 #include "core/unused.hpp"
 
-#include <string.h>
-#include <vector>
+#include <algorithm>
 #include <array>
-#include <thread>
+#include <cstring>
 #include <sstream>
+#include <thread>
 #include <type_traits>
+#include <vector>
+
 #ifdef USE_ESSL
 #include <fftw3_essl.h>
 #else


### PR DESCRIPTION
I'm leaving this as a draft for now because more commits may follow

- Fix forgotten include of `<limits>`
- Link Arm Performance Libraries with Fortran runtime library when using GCC
- Minor cleanups
- Fix of -Wclass-memaccess warning in GCC