### PR TITLE
Add .mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,11 @@
+Matthias Werner <tdd11235813@users.noreply.github.com>
+Matthias Werner <tdd11235813@users.noreply.github.com> <tdd11235813@blogspot.com>
+Matthias Werner <tdd11235813@users.noreply.github.com> <matthias.werner1@tu-dresden.de>
+
+Peter Steinbach <p.steinbach@hzdr.de>
+Peter Steinbach <p.steinbach@hzdr.de> <steinbac@mpi-cbg.de>
+Peter Steinbach <p.steinbach@hzdr.de> <steinbach@scionics.de>
+
+David Pape <d.pape@hzdr.de>
+David Pape <d.pape@hzdr.de> <davidpape1995@gmail.com>
+David Pape <d.pape@hzdr.de> <zyzzyxdonta@posteo.de>


### PR DESCRIPTION
Hi!

I felt like doing a bit of coding during the holidays. I'll probably do some more pull requests after this one (depending on how it goes 😄), so I thought I'd use this little cosmetic change as an announcement. 😁 Please don't feel pressured to look into any of this during the holidays.

---

This pull request adds a `.mailmap` file which helps both tidy up the git log as well as improve the [display of contributors on GitHub](https://github.com/mpicbg-scicomp/gearshifft/graphs/contributors).

Here's the output of `git shortlog -esn` before adding the file:

```
   244  Matthias Werner <Matthias.Werner1@tu-dresden.de>
    80  Peter Steinbach <steinbac@mpi-cbg.de>
    76  Peter Steinbach <steinbach@scionics.de>
    47  Pape, David (FWCC) - 139658 <d.pape@hzdr.de>
    36  Matthias Werner <tdd11235813@users.noreply.github.com>
    14  David Pape <davidpape1995@gmail.com>
    11  M. Werner <tdd11235813@users.noreply.github.com>
     8  Mario Emmenlauer <mario@emmenlauer.de>
     7  tdd11235813 <tdd11235813@blogspot.com>
     6  Peter Steinbach <p.steinbach@hzdr.de>
     6  steinbac <steinbac@mpi-cbg.de>
     5  David Pape <zyzzyxdonta@posteo.de>
     5  Steinbach, Dr. rer. nat. Peter (FWCC) - 120595 <p.steinbach@hzdr.de>
     4  David Pape <d.pape@hzdr.de>
     3  Matthias Werner <matthias.werner1@tu-dresden.de>
     2  steinbac <steinbach@scionics.de>
```

and afterwards:

```
   301  Matthias Werner <tdd11235813@users.noreply.github.com>
   175  Peter Steinbach <p.steinbach@hzdr.de>
    70  David Pape <d.pape@hzdr.de>
     8  Mario Emmenlauer <mario@emmenlauer.de>
```
