### PR TITLE
Use std::generate to generate benchmark data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 debug*
 release*
+*.csv
 *.out
 *.err
 *.log

--- a/inc/core/benchmark_data.hpp
+++ b/inc/core/benchmark_data.hpp
@@ -14,9 +14,10 @@
 #include <boost/noncopyable.hpp>
 #pragma GCC diagnostic pop
 
+#include <algorithm>
+#include <cmath>
 #include <numeric>
 #include <vector>
-#include <cmath>
 
 namespace gearshifft {
 
@@ -108,18 +109,17 @@ namespace gearshifft {
         // (y[0] of FFT(x) is sum of input values)
         // Overflow leads to nan or inf values and iFFT(FFT()) cannot be validated
         // This method still leads to nan's when size_ >= (1<<20)
-        for( size_t i=0; i<size_; ++i )
-        {
-          if( i%(size_/limit16)==0 )
-            data_linear_[i] = 0.1;
-          else
-            data_linear_[i] = 0.0;
-        }
+        auto gen = [this]() {
+          static size_t i = 0;
+          return (i++ % (size_ / limit16) == 0) ? 0.1 : 0.0;
+        };
+        std::generate(data_linear_.begin(), data_linear_.end(), gen);
       } else {
-        for( size_t i=0; i<size_; ++i )
-        {
-          data_linear_[i] = 0.125*(i&7);
-        }
+        auto gen = []() {
+          static size_t i = 0;
+          return 0.125 * (i++ & 7);
+        };
+        std::generate(data_linear_.begin(), data_linear_.end(), gen);
       }
 
     }
@@ -134,4 +134,5 @@ namespace gearshifft {
 
   };
 } // gearshifft
+
 #endif

--- a/inc/core/benchmark_data.hpp
+++ b/inc/core/benchmark_data.hpp
@@ -136,7 +136,6 @@ namespace gearshifft {
       } else {
         std::generate(data_linear_.begin(), data_linear_.end(), BenchmarkDataGenerator<RealType>{});
       }
-
     }
 
     BenchmarkData() = default;

--- a/inc/core/benchmark_data.hpp
+++ b/inc/core/benchmark_data.hpp
@@ -23,14 +23,14 @@ namespace gearshifft {
 
   template <typename RealType>
   struct BenchmarkDataGenerator {
-    BenchmarkDataGenerator(const size_t) {}
+    BenchmarkDataGenerator(const std::size_t) {}
 
     RealType operator()() {
       return 0.125 * (i_++ & 7);
     }
 
   private:
-    size_t i_ = 0;
+    std::size_t i_ = 0;
   };
 
   // To avoid overflows float16 data non-zero points are limited (y[0] of FFT(x)
@@ -38,16 +38,16 @@ namespace gearshifft {
   // cannot be validated. This method still leads to nan's when size_ >= (1<<20).
   template <>
   struct BenchmarkDataGenerator<float16> {
-    BenchmarkDataGenerator(const size_t size) : size_(size) {}
+    BenchmarkDataGenerator(const std::size_t size) : size_(size) {}
 
     float16 operator()() {
       return (i_++ % (size_ / LIMIT16) == 0) ? 0.1_h : 0.0_h;
     }
 
   private:
-    size_t i_ = 0;
-    const size_t size_;
-    static constexpr size_t LIMIT16 = 1 << 15;
+    std::size_t i_ = 0;
+    const std::size_t size_;
+    static constexpr std::size_t LIMIT16 = 1 << 15;
   };
 
 /**

--- a/inc/core/benchmark_data.hpp
+++ b/inc/core/benchmark_data.hpp
@@ -38,15 +38,20 @@ namespace gearshifft {
   // cannot be validated. This method still leads to nan's when size_ >= (1<<20).
   template <>
   struct BenchmarkDataGenerator<float16> {
-    BenchmarkDataGenerator(const std::size_t size) : size_(size) {}
+    BenchmarkDataGenerator(const std::size_t size)
+    : sparse_values_(size > LIMIT16), quotient_(size / LIMIT16) {}
 
     float16 operator()() {
-      return (i_++ % (size_ / LIMIT16) == 0) ? 0.1_h : 0.0_h;
+      if (sparse_values_) {
+        return static_cast<float16>((i_++ % quotient_ == 0) ? 0.1 : 0.0);
+      }
+      return static_cast<float16>(0.125 * (i_++ & 7));
     }
 
   private:
     std::size_t i_ = 0;
-    const std::size_t size_;
+    const bool sparse_values_;
+    const std::size_t quotient_;
     static constexpr std::size_t LIMIT16 = 1 << 15;
   };
 

--- a/inc/core/complex-half.hpp
+++ b/inc/core/complex-half.hpp
@@ -4,7 +4,6 @@
 #if GEARSHIFFT_FLOAT16_SUPPORT == 0
 
 struct float16 {};
-inline float16 operator""_h(long double) { return float16{}; }
 
 #else
 
@@ -13,7 +12,6 @@ inline float16 operator""_h(long double) { return float16{}; }
 #include <complex>
 
 using float16 = half_float::half;
-using namespace half_float::literal;
 
 namespace gearshifft {
 

--- a/inc/core/complex-half.hpp
+++ b/inc/core/complex-half.hpp
@@ -4,6 +4,7 @@
 #if GEARSHIFFT_FLOAT16_SUPPORT == 0
 
 struct float16 {};
+inline float16 operator""_h(long double) { return float16{}; }
 
 #else
 
@@ -12,6 +13,7 @@ struct float16 {};
 #include <complex>
 
 using float16 = half_float::half;
+using namespace half_float::literal;
 
 namespace gearshifft {
 

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -43,6 +43,7 @@ using FFTs              = List<Inplace_Real,
                                Outplace_Complex >;
 using Precisions        = gearshifft::DefaultPrecisionsWithoutHalfPrecision;
 using FFT_Is_Normalized = std::false_type;
+
 #elif defined(ROCFFT_ENABLED)
 #include "libraries/rocfft/rocfft.hpp"
 


### PR DESCRIPTION
This pull request implements benchmark data generation with generator structs used with `std::generate`. This clearly communicates the intent, making the code more readable than the raw loops used before.

**TODO:**

- [x] Actually try to compile this with cuFFT and `float16` support.

**Thoughts:**

It would also be interesting to know whether the sparseness of the benchmark data (`float16` case) affects results. There are even special FFT implementations for certain kinds of sparse data. With that in mind, it might even make sense to make benchmark data generators user-selectable at compile time. (Not now but as a possible new feature ;-))
