### PR TITLE
Fix invalid chunk size error

### DIFF
--- a/inc/core/benchmark.hpp
+++ b/inc/core/benchmark.hpp
@@ -8,8 +8,6 @@
 #include "benchmark_suite.hpp"
 #include "gearshifft_version.hpp"
 
-// see https://www.boost.org/doc/libs/1_65_1/libs/test/doc/html/boost_test/usage_variants.html
-// Single-header usage variant
 // No BOOST_TEST_MODULE as entry point is customized
 #include <boost/test/unit_test.hpp>
 

--- a/inc/core/benchmark.hpp
+++ b/inc/core/benchmark.hpp
@@ -11,7 +11,7 @@
 // see https://www.boost.org/doc/libs/1_65_1/libs/test/doc/html/boost_test/usage_variants.html
 // Single-header usage variant
 // No BOOST_TEST_MODULE as entry point is customized
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 namespace gearshifft {
 

--- a/inc/core/benchmark_executor.hpp
+++ b/inc/core/benchmark_executor.hpp
@@ -10,7 +10,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
-#include <boost/test/included/unit_test.hpp> // Single-header usage variant
+#include <boost/test/unit_test.hpp>
 #pragma GCC diagnostic pop
 
 #include <type_traits>

--- a/inc/core/benchmark_suite.hpp
+++ b/inc/core/benchmark_suite.hpp
@@ -10,7 +10,7 @@
 
 #include <boost/bind/bind.hpp>
 
-#include <boost/test/included/unit_test.hpp> // Single-header usage variant
+#include <boost/test/unit_test.hpp>
 #include <boost/test/unit_test_suite.hpp>
 #include <boost/mpl/for_each.hpp>
 

--- a/test/test_clfft.cpp
+++ b/test/test_clfft.cpp
@@ -3,7 +3,7 @@
 #include "core/types.hpp"
 #include "libraries/clfft/clfft_helper.hpp"
 
-#include <boost/test/included/unit_test.hpp> // Single-header usage variant
+#include <boost/test/unit_test.hpp>
 #include <boost/mpl/list.hpp>
 
 using test_types = boost::mpl::list<float, double>;

--- a/test/test_clfft_global_fixture.cpp
+++ b/test/test_clfft_global_fixture.cpp
@@ -1,7 +1,7 @@
 #define BOOST_TEST_MODULE TestClFFTGlobalFixture
 
 #include "libraries/clfft/clfft_helper.hpp"
-#include <boost/test/included/unit_test.hpp> // Single-header usage variant
+#include <boost/test/unit_test.hpp>
 
 using namespace gearshifft::ClFFT;
 

--- a/test/test_cufft.cpp
+++ b/test/test_cufft.cpp
@@ -1,7 +1,7 @@
 #define BOOST_TEST_MODULE TestCuFFT
 
 #include "libraries/cufft/cufft_helper.hpp"
-#include <boost/test/included/unit_test.hpp> // Single-header usage variant
+#include <boost/test/unit_test.hpp>
 #include <array>
 #include <iostream>
 

--- a/test/test_fftw.cpp
+++ b/test/test_fftw.cpp
@@ -1,7 +1,7 @@
 #define BOOST_TEST_MODULE TestFFTW
 
 #include <fftw3.h>
-#include <boost/test/included/unit_test.hpp> // Single-header usage variant
+#include <boost/test/unit_test.hpp>
 #include <iostream>
 
 BOOST_AUTO_TEST_CASE( FFT1DSingle, * boost::unit_test::tolerance(0.0001f) )

--- a/test/test_rocfft.cpp
+++ b/test/test_rocfft.cpp
@@ -5,7 +5,7 @@
 #include <hip/hip_vector_types.h>
 #include <rocfft.h>
 
-#include <boost/test/included/unit_test.hpp> // Single-header usage variant
+#include <boost/test/unit_test.hpp>
 
 #include <cstdint>
 

--- a/test/test_rocfft_helper.cpp
+++ b/test/test_rocfft_helper.cpp
@@ -1,7 +1,7 @@
 #define BOOST_TEST_MODULE TestrocFFTHelper
 #include "libraries/rocfft/rocfft_helper.hpp"
 
-#include <boost/test/included/unit_test.hpp> // Single-header usage variant
+#include <boost/test/unit_test.hpp>
 
 #include <iostream>
 #include <vector>

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1,7 +1,7 @@
 // test cases for development purposes
 #define BOOST_TEST_MODULE TestContext
 
-#include <boost/test/included/unit_test.hpp> // Single-header usage variant
+#include <boost/test/unit_test.hpp>
 
 #ifdef DEV_TESTS
 #if defined(CLFFT_ENABLED)


### PR DESCRIPTION
Under certain circumstances (including running the tests), gearshifft runs successfully but then fails during program finalization, showing an error:

malloc_consolidate(): invalid chunk size

This is due to the fact that boost unit test is linked (either statically or dynamically) but the single header variant is included everywhere.

This pull request fixes the error by including the correct boost unit test header for usage in linking scenarios.

More information: https://www.boost.org/doc/libs/1_59_0/libs/test/doc/html/boost_test/usage_variants.html