### PR TITLE
Simplify options handling

### DIFF
--- a/inc/core/benchmark.hpp
+++ b/inc/core/benchmark.hpp
@@ -33,10 +33,10 @@ namespace gearshifft {
     }
 
     void configure(int argc, char* argv[]) {
-      std::vector<char*> vargv(argv, argv+argc);
       boost_vargv_.clear();
       boost_vargv_.emplace_back(argv[0]); // [0] = name of application
-      auto parseResult = Context::options().parse(vargv, boost_vargv_);
+
+      auto parseResult = Context::options().parse(argc, argv);
       switch (parseResult) {
         case 0:  break;
         case 1:  info_only_ = true; break;

--- a/inc/core/options.hpp
+++ b/inc/core/options.hpp
@@ -8,7 +8,6 @@
 #include <boost/core/noncopyable.hpp>
 #pragma GCC diagnostic pop
 #include <string>
-#include <vector>
 
 namespace gearshifft {
 
@@ -24,7 +23,6 @@ namespace gearshifft {
   public:
 
     OptionsDefault();
-    ~OptionsDefault();
 
     bool getHelp() const {
       return help_;
@@ -71,7 +69,7 @@ namespace gearshifft {
     void parseExtent( const std::string& extent );
 
     /// processes command line arguments and apply the values to the variables
-    int parse(std::vector<char*>&, std::vector<char*>&);
+    int parse(int, char *[]);
 
     const Extents1DVec& getExtents1D() const {
       return vector1D_;
@@ -106,7 +104,6 @@ namespace gearshifft {
     bool version_ = false;
     bool listBenchmarks_ = false;
     bool listDevices_ = false;
-    char* tmp_ = nullptr;
 
     Extents1DVec vector1D_;
     Extents2DVec vector2D_;

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -1,8 +1,6 @@
 #include "core/benchmark.hpp"
 #include "core/types.hpp"
 
-#include <cstdlib>
-
 // ----------------------------------------------------------------------------
 template<typename... Types>
 using List = gearshifft::List<Types...>;
@@ -60,9 +58,6 @@ using FFT_Is_Normalized = std::false_type;
 
 int main( int argc, char* argv[] )
 {
-  char reportLevel[] = "BOOST_TEST_REPORT_LEVEL=no";
-  putenv(reportLevel);
-
   int ret = 0;
   try {
     gearshifft::Benchmark<Context> benchmark;


### PR DESCRIPTION
Use environment variables for the runtime configuration of Boost Test. This simplifies the code since we can use setenv which can handle const char pointers and copies their string contents.

Also, remove unnecessary usage of vector for options parsing.